### PR TITLE
Sitemap URL is missing baseUR

### DIFF
--- a/site/hugo.preview.yaml
+++ b/site/hugo.preview.yaml
@@ -1,3 +1,4 @@
+baseURL: https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net
 Environment: "preview"
 minifyOutput: true
 

--- a/site/hugo.production.yaml
+++ b/site/hugo.production.yaml
@@ -1,0 +1,3 @@
+baseURL: https://scrumexpansion.org
+Environment: "production"
+minifyOutput: true


### PR DESCRIPTION
✨ feat(config): add production config for hugo

- introduce hugo.production.yaml for production environment
- set baseURL to https://scrumexpansion.org
- enable output minification for production

✨ feat(config): update preview config for hugo

- add baseURL to hugo.preview.yaml for preview environment
- ensure consistency with production setup