### PR TITLE
Fix for build concurancy

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.ref }}
   cancel-in-progress: true
 
 defaults:


### PR DESCRIPTION
👷 ci(workflows): update concurrency group for pull requests
- modify concurrency group to use pull request SHA for better isolation