### PR TITLE
👷 ci(workflows): update condition for publish site job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -246,7 +246,7 @@ jobs:
     name: "Publish Site"
     runs-on: ubuntu-latest
     needs: [Setup, BuildSite]
-    if: ${{ success() && github.event.repository.fork == false }}
+    if: ${{ success() && (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) }}
     outputs:
       static_web_app_url: ${{ steps.azureDeploy.outputs.static_web_app_url }}
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -167,6 +167,8 @@ jobs:
                 - PR_Branch: ${{ github.head_ref || github.ref_name }}
                 - PR_Commit: ${{ github.sha }}
                 - Is_Fork: ${{ github.event.repository.fork }}
+                - PR_Repository: ${{ github.event.pull_request.head.repo.full_name }}
+                - PR_Base_Repository: ${{ github.event.pull_request.base.repo.full_name }}
           "@
           echo $markdown >> $Env:GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
- modify condition to ensure publish site job runs on non-fork pull requests