### PR TITLE
📝 docs(README): add live and preview site links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,11 @@
 
 Welcome to the documentation for the **Scrum Guide Expansion Pack** project. This documentation provides comprehensive information about the project structure, development workflow, and contribution guidelines.
 
+## 🌐 Live Sites
+
+- **Production**: [scrumexpansion.org](https://scrumexpansion.org) - **Live production site**
+- **Preview**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/) - **Test your contributions here before they go live**
+
 ## Quick Navigation
 
 - [🚀 Getting Started](./getting-started.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,6 +2,11 @@
 
 We welcome and appreciate contributions from the community! This guide outlines how you can contribute to the Scrum Guide Expansion Pack project.
 
+## 🌐 Live Sites
+
+- **Production**: [scrumexpansion.org](https://scrumexpansion.org) - **Live production site**
+- **Preview**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/) - **Test your contributions here before they go live**
+
 ## Table of Contents
 
 - [Ways to Contribute](#ways-to-contribute)
@@ -73,6 +78,11 @@ Follow the [Getting Started Guide](./getting-started.md) to set up your developm
 - Look for issues labeled `good first issue` for beginners
 - Check issues labeled `help wanted` for priority items
 - Create a new issue if you find a bug or have a feature request
+
+### 4. Test Your Ideas
+
+- **Review the live site**: [scrumexpansion.org](https://scrumexpansion.org)
+- **Test contributions on preview**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/) - See how your changes will look before they go to production
 
 ## Contribution Workflow
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,11 @@
 
 This guide covers the deployment process for the Scrum Guide Expansion Pack using Azure Static Web Apps and GitHub Actions.
 
+## 🌐 Live Sites
+
+- **Production**: [scrumexpansion.org](https://scrumexpansion.org) - **Live production site**
+- **Preview**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/) - **Test environment for pre-production changes**
+
 ## Deployment Overview
 
 The project uses **Azure Static Web Apps** for hosting with automated deployments triggered by GitHub Actions. The deployment pipeline supports multiple environments for different stages of development.
@@ -10,14 +15,14 @@ The project uses **Azure Static Web Apps** for hosting with automated deployment
 
 ### 🚀 Production Environment
 
-- **URL**: [https://scrumexpansion.org](https://scrumexpansion.org)
+- **URL**: [scrumexpansion.org](https://scrumexpansion.org) - **Live production site**
 - **Branch**: `main`
 - **Configuration**: `staticwebapp.config.production.json`
 - **Hugo Config**: `hugo.yaml`
 
 ### 🔄 Preview Environment
 
-- **URL**: [https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net)
+- **URL**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/) - **Test environment for pre-production changes**
 - **Branch**: `preview`
 - **Configuration**: `staticwebapp.config.preview.json`
 - **Hugo Config**: `hugo.preview.yaml`

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,11 @@
 
 This guide provides detailed information for developers working on the Scrum Guide Expansion Pack project.
 
+## 🌐 Live Sites for Reference
+
+- **Production**: [scrumexpansion.org](https://scrumexpansion.org) - **Live production site**
+- **Preview**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/) - **Test environment with latest changes**
+
 ## Development Environment Setup
 
 ### Prerequisites

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,6 +84,13 @@ hugo server --buildDrafts --buildFuture --bind 0.0.0.0
 
 Navigate to `http://localhost:1313` to view the site locally.
 
+### 6. Compare with Live Sites
+
+To see how your local changes compare with the live sites:
+
+- **Production**: [scrumexpansion.org](https://scrumexpansion.org) - The live production site
+- **Preview**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/) - Test environment with latest changes
+
 ## Development Server Options
 
 | Command                      | Description                               |

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,10 @@
 
 ## Visit the Guide
 
-**[scrumexpansion.org](https://scrumexpansion.org)**\*\* - Start reading now!\*\*
+### 🌐 Live Sites
+
+- **Production**: [scrumexpansion.org](https://scrumexpansion.org) - **Start reading now!**
+- **Preview**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/) - **Test latest changes before production**
 
 ## What is This?
 
@@ -49,7 +52,13 @@ Making Scrum knowledge accessible globally is essential.
 
 ## Access the Guide
 
-- **Read online**: [scrumexpansion.org](https://scrumexpansion.org)
+### 📖 Read Online
+
+- **Production**: [scrumexpansion.org](https://scrumexpansion.org)
+- **Preview**: [agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/)
+
+### 📄 Download Options
+
 - **Download PDF**: [Available languages](https://scrumexpansion.org/download)
 
 ## How to Contribute
@@ -103,9 +112,10 @@ See [LICENSE](./LICENSE) for complete terms.
 
 ## Getting Started
 
-1. **[Read the expansion](https://scrumexpansion.org)**
-2. **[Engage with the community](https://github.com/ScrumGuides/ScrumGuide-ExpansionPack/discussions)**
-3. **[Support translations](https://github.com/ScrumGuides/ScrumGuide-ExpansionPack/discussions)**
-4. **[Review contribution guidelines](./docs/contributing.md)**
+1. **[Read the expansion](https://scrumexpansion.org)** - Production site
+2. **[Test latest changes](https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/)** - Preview site  
+3. **[Engage with the community](https://github.com/ScrumGuides/ScrumGuide-ExpansionPack/discussions)**
+4. **[Support translations](https://github.com/ScrumGuides/ScrumGuide-ExpansionPack/discussions)**
+5. **[Review contribution guidelines](./docs/contributing.md)**
 
 **Together, we're advancing Scrum practice for modern product development challenges.**


### PR DESCRIPTION
- include production and preview site links for easy access to live and test environments
- enhance visibility of deployment and contribution testing stages across documentation files