### PR TITLE
🔧 chore(gitversion): update versioning mode and next version

### DIFF
--- a/.github/GitVersion.yml
+++ b/.github/GitVersion.yml
@@ -1,11 +1,11 @@
 assembly-versioning-scheme: MajorMinorPatch
-mode: ContinuousDelivery
+mode: ContinuousDeployment
 continuous-delivery-fallback-tag: "Canary"
-next-version: 0.5.0
+next-version: 1.0.0
 branches:
   main:
-    mode: ContinuousDelivery
-    tag: "Preview"
+    mode: ContinuousDeployment
+    tag: "preview"
     increment: Patch
     is-mainline: true
     prevent-increment-of-merged-branch-version: false


### PR DESCRIPTION
- change mode from ContinuousDelivery to ContinuousDeployment
- update next-version from 0.5.0 to 1.0.0
- modify branch mode and tag for consistency