### PR TITLE
Enable preview translations

### DIFF
--- a/site/hugo.local.yaml
+++ b/site/hugo.local.yaml
@@ -5,3 +5,11 @@ buildFuture: true
 buildExpired: true
 
 disableAliases: true
+
+languages:
+  tlh:
+    disabled: true
+  fa:
+    disabled: true
+  nl:
+    disabled: true

--- a/site/hugo.local.yaml
+++ b/site/hugo.local.yaml
@@ -9,7 +9,3 @@ disableAliases: true
 languages:
   tlh:
     disabled: true
-  fa:
-    disabled: true
-  nl:
-    disabled: true

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -24,7 +24,7 @@ languages:
       description: "ScrumExpansion.org hosts the Scrum Guide Expansion Pack—modern guidance for applying Scrum to complex work, AI, and adaptive strategy."
       keywords: "Scrum, ScrumExpansion.org, Scrum Guide Expansion Pack, Scrum guidance, advanced Scrum practices, Scrum for modern work, adaptive enterprise, agile product delivery, empirical Scrum, product thinking, complexity theory in Scrum, Scrum leadership, professional Scrum, Scrum and AI, Scrum resources, Scrum learning hub, Scrum community site"
   tlh:
-    languageName: Klingon
+    languageName: Klingon (reference)
     weight: 1000
     languageCode: "tlh"
     languageDirection: "ltr"

--- a/site/i18n/en.yaml
+++ b/site/i18n/en.yaml
@@ -80,7 +80,29 @@
   translation: "You can also download this guide as a PDF for offline reading."
 
 - id: guide_pdf_intro_link
-  translation: "download it here"
+  translation: "Download PDF"
+
+# Preview Translations functionality
+- id: download_preview_translations
+  translation: "Preview Translations"
+
+- id: download_preview_description
+  translation: "These translations are available in preview and will be moved to the main site once ready."
+
+- id: download_visit_preview
+  translation: "Visit preview site"
+
+- id: download_table_status
+  translation: "Status"
+
+- id: download_preview_status
+  translation: "In Preview"
+
+- id: download_preview_action
+  translation: "Preview"
+
+- id: download_discussion_action
+  translation: "Discussion"
 
 # Download page translations
 - id: download_page_title

--- a/site/i18n/fa.yaml
+++ b/site/i18n/fa.yaml
@@ -142,3 +142,25 @@
 
 - id: read_online_action
   translation: "مطالعه آنلاین"
+
+# Preview Translations functionality
+- id: download_preview_translations
+  translation: "ترجمه‌های پیش‌نمایش"
+
+- id: download_preview_description
+  translation: "این ترجمه‌ها در پیش‌نمایش موجود هستند و پس از آماده شدن به سایت اصلی منتقل خواهند شد."
+
+- id: download_visit_preview
+  translation: "مشاهده سایت پیش‌نمایش"
+
+- id: download_table_status
+  translation: "وضعیت"
+
+- id: download_preview_status
+  translation: "در پیش‌نمایش"
+
+- id: download_preview_action
+  translation: "پیش‌نمایش"
+
+- id: download_discussion_action
+  translation: "بحث"

--- a/site/i18n/nl.yaml
+++ b/site/i18n/nl.yaml
@@ -158,3 +158,25 @@
 
 - id: guide_pdf_intro_link
   translation: "Download PDF"
+
+# Preview Translations functionality
+- id: download_preview_translations
+  translation: "Preview Vertalingen"
+
+- id: download_preview_description
+  translation: "Deze vertalingen zijn beschikbaar in preview en worden naar de hoofdsite verplaatst zodra ze klaar zijn."
+
+- id: download_visit_preview
+  translation: "Bezoek preview site"
+
+- id: download_table_status
+  translation: "Status"
+
+- id: download_preview_status
+  translation: "In Preview"
+
+- id: download_preview_action
+  translation: "Preview"
+
+- id: download_discussion_action
+  translation: "Discussie"

--- a/site/layouts/index.languages.json
+++ b/site/layouts/index.languages.json
@@ -9,7 +9,8 @@
         "weight": {{ $langConfig.Weight | default 1 }},
         "title": "{{ $langConfig.Title }}",
         "nativeName": "{{ $langConfig.LanguageName }}",
-        "discussionId": {{ $langConfig.Params.discussionId | default 124 }}
+        "discussionId": {{ $langConfig.Params.discussionId | default 124 }},
+        "status": "{{ $langConfig.Params.status | default "active" }}"
       }
       {{- $first = false -}}
     {{- end -}}

--- a/site/layouts/translations/list.html
+++ b/site/layouts/translations/list.html
@@ -221,7 +221,7 @@
 
             {{- $previewOnlyLanguages := slice }}
             {{- range $previewLanguagesData.languages }}
-              {{- if not (in $currentLanguageCodes .code) }}
+              {{- if and (not (in $currentLanguageCodes .code)) (ne .status "reference") }}
                 {{- $previewOnlyLanguages = $previewOnlyLanguages | append . }}
               {{- end }}
             {{- end }}

--- a/site/layouts/translations/list.html
+++ b/site/layouts/translations/list.html
@@ -137,60 +137,60 @@
               {{- $basePage := site.GetPage "guide" }}
               {{- range $basePage.AllTranslations }}
                 {{- if ne .Language.Lang "en" }}
-                <tr>
-                  <td>
-                    {{ .Language.LanguageName }}
-                    {{- if .Date }}
-                      ({{ .Date.Format "January 2006" }})
-                    {{- else }}
-                      ({{ $guidePage.Date.Format "January 2006" }})
-                    {{- end }}
-                  </td>
-                  <td>
-                    {{- if .Params.contributors }}
-                      {{- range $index, $contributor := .Params.contributors }}
-                        {{- if $index }},{{ end }}
-                        {{- if $contributor.link }}
-                          <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
+                  <tr>
+                    <td>
+                      {{ .Language.LanguageName }}
+                      {{- if .Date }}
+                        ({{ .Date.Format "January 2006" }})
+                      {{- else }}
+                        ({{ $guidePage.Date.Format "January 2006" }})
+                      {{- end }}
+                    </td>
+                    <td>
+                      {{- if .Params.contributors }}
+                        {{- range $index, $contributor := .Params.contributors }}
+                          {{- if $index }},{{ end }}
+                          {{- if $contributor.link }}
+                            <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
+                              {{ $contributor.name }}
+                              <i class="fa-solid fa-external-link-alt ms-1"></i>
+                            </a>
+                          {{- else }}
                             {{ $contributor.name }}
-                            <i class="fa-solid fa-external-link-alt ms-1"></i>
+                          {{- end }}
+                        {{- end }}
+                      {{- else }}
+                        {{ i18n "download_community_contributors" . }}
+                      {{- end }}
+                    </td>
+                    <td>
+                      <div class="d-flex gap-2">
+                        <!-- Online Reading Link -->
+                        <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
+                          <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                        </a>
+                        <!-- PDF Download Link -->
+                        {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
+                        {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
+                        {{- if $pdfResource }}
+                          <a
+                            href="{{ $pdfResource.RelPermalink }}"
+                            class="btn btn-primary btn-sm pdf-download"
+                            download
+                            data-language="{{ .Language.LanguageName }}"
+                            data-language-code="{{ .Language.Lang }}"
+                            data-type="Translation"
+                            data-filename="{{ $pdfResource.Name }}">
+                            <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
                           </a>
                         {{- else }}
-                          {{ $contributor.name }}
+                          <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
+                            <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
+                          </a>
                         {{- end }}
-                      {{- end }}
-                    {{- else }}
-                      {{ i18n "download_community_contributors" . }}
-                    {{- end }}
-                  </td>
-                  <td>
-                    <div class="d-flex gap-2">
-                      <!-- Online Reading Link -->
-                      <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
-                        <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
-                      </a>
-                      <!-- PDF Download Link -->
-                      {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
-                      {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
-                      {{- if $pdfResource }}
-                        <a
-                          href="{{ $pdfResource.RelPermalink }}"
-                          class="btn btn-primary btn-sm pdf-download"
-                          download
-                          data-language="{{ .Language.LanguageName }}"
-                          data-language-code="{{ .Language.Lang }}"
-                          data-type="Translation"
-                          data-filename="{{ $pdfResource.Name }}">
-                          <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
-                        </a>
-                      {{- else }}
-                        <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
-                          <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
-                        </a>
-                      {{- end }}
-                    </div>
-                  </td>
-                </tr>
+                      </div>
+                    </td>
+                  </tr>
                 {{- end }}
               {{- end }}
               <!-- Add Translation Row -->

--- a/site/layouts/translations/list.html
+++ b/site/layouts/translations/list.html
@@ -136,6 +136,7 @@
             <tbody>
               {{- $basePage := site.GetPage "guide" }}
               {{- range $basePage.AllTranslations }}
+                {{- if ne .Language.Lang "en" }}
                 <tr>
                   <td>
                     {{ .Language.LanguageName }}
@@ -190,6 +191,7 @@
                     </div>
                   </td>
                 </tr>
+                {{- end }}
               {{- end }}
               <!-- Add Translation Row -->
               <tr class="table-light">
@@ -203,6 +205,79 @@
             </tbody>
           </table>
         </div>
+
+        <!-- Preview Translations -->
+        {{- $previewLanguagesUrl := printf "%slanguages.json" .Site.Params.previewSiteUrl }}
+        {{- $previewLanguagesResponse := resources.GetRemote $previewLanguagesUrl }}
+        {{- if $previewLanguagesResponse }}
+          {{- $previewLanguagesData := $previewLanguagesResponse | transform.Unmarshal }}
+          {{- if $previewLanguagesData.languages }}
+            {{- $currentLanguageCodes := slice }}
+            {{- $basePage := site.GetPage "guide" }}
+            {{- range $basePage.AllTranslations }}
+              {{- $currentLanguageCodes = $currentLanguageCodes | append .Language.Lang }}
+            {{- end }}
+            {{- $currentLanguageCodes = $currentLanguageCodes | append .Site.Language.Lang }}
+
+            {{- $previewOnlyLanguages := slice }}
+            {{- range $previewLanguagesData.languages }}
+              {{- if not (in $currentLanguageCodes .code) }}
+                {{- $previewOnlyLanguages = $previewOnlyLanguages | append . }}
+              {{- end }}
+            {{- end }}
+
+            {{- if gt (len $previewOnlyLanguages) 0 }}
+              <h2 class="mb-3">{{ i18n "download_preview_translations" . | default "Preview Translations" }}</h2>
+              <p class="text-muted mb-3">
+                <small>
+                  {{ i18n "download_preview_description" . | default "These translations are available in preview and will be moved to the main site once ready." }}
+                  <a href="{{ .Site.Params.previewSiteUrl }}" target="_blank" rel="noopener" class="text-decoration-none">
+                    {{ i18n "download_visit_preview" . | default "Visit preview site" }}
+                    <i class="fa-solid fa-external-link-alt ms-1"></i>
+                  </a>
+                </small>
+              </p>
+              <div class="table-responsive mb-5">
+                <table class="table table-striped">
+                  <thead>
+                    <tr>
+                      <th scope="col">{{ i18n "download_table_language" . }}</th>
+                      <th scope="col">{{ i18n "download_table_status" . | default "Status" }}</th>
+                      <th scope="col">{{ i18n "download_table_action" . }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {{- range $previewOnlyLanguages }}
+                      <tr>
+                        <td>{{ .name }}</td>
+                        <td>
+                          <span class="badge bg-warning text-dark">
+                            <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                          </span>
+                        </td>
+                        <td>
+                          <div class="d-flex gap-2">
+                            <!-- Preview Reading Link -->
+                            <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
+                              <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
+                            </a>
+                            <!-- Discussion Link -->
+                            {{- if .discussionId }}
+                              <a href="{{ $.Site.Params.githubUrl }}/discussions/{{ .discussionId }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
+                                <i class="fa-solid fa-comments me-1"></i>{{ i18n "download_discussion_action" . | default "Discussion" }}
+                              </a>
+                            {{- end }}
+                          </div>
+                        </td>
+                      </tr>
+                    {{- end }}
+                  </tbody>
+                </table>
+              </div>
+            {{- end }}
+          {{- end }}
+        {{- end }}
+
       </div>
     </div>
   </section>

--- a/site/layouts/translations/list.html
+++ b/site/layouts/translations/list.html
@@ -24,97 +24,193 @@
 
         <!-- Official Version -->
         <h2 class="mb-3">{{ i18n "download_official_version" . }}</h2>
-        <div class="table-responsive mb-5">
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th scope="col">{{ i18n "download_table_language" . }}</th>
-                <th scope="col">{{ i18n "download_table_written_by" . }}</th>
-                <th scope="col">{{ i18n "download_table_action" . }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>{{ .Site.Language.LanguageName }} ({{ $guidePage.Date.Format "January 2006" }}) - {{ i18n "download_official_current_version" . }}</td>
-                <td>
-                  {{- $creators := .Site.GetPage "/creators" }}
-                  {{- $creatorPages := $creators.Pages }}
-                  {{- range $index, $creator := $creatorPages }}
-                    {{- if $index }},{{ end }}
-                    {{- if gt (len $creatorPages) 1 }}{{ if eq $index (sub (len $creatorPages) 1) }}&{{ end }}{{ end }}
-                    <a href="{{ $creator.Permalink }}" class="text-decoration-none">{{ $creator.Title }}</a>
-                  {{- end }}
-                </td>
-                <td>
-                  <div class="d-flex gap-2">
-                    <!-- Online Reading Link -->
-                    {{ if $isComingSoon }}
-                      <a href="#" class="btn btn-outline-secondary btn-sm disabled">{{ i18n "read_online_action" . }}</a>
-                    {{ else }}
-                      <a href="{{ $guidePage.Permalink }}" class="btn btn-outline-secondary btn-sm">
-                        <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
-                      </a>
-                    {{ end }}
-                    <!-- PDF Download Link -->
-                    {{ if $isComingSoon }}
-                      <a href="#" class="btn btn-primary btn-sm disabled">{{ i18n "download_coming_soon" . }}</a>
-                    {{ else }}
-                      {{- $pdfPattern := printf "pdf/*.en.pdf" }}
 
-                      {{- $pdfResource := $guidePage.Resources.GetMatch $pdfPattern }}
-                      {{- if $pdfResource }}
-                        <a href="{{ $pdfResource.RelPermalink }}" class="btn btn-primary btn-sm pdf-download" download data-language="English" data-language-code="en" data-type="Official" data-filename="{{ $pdfResource.Name }}">
-                          <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" . }}
-                        </a>
-                      {{- else }}
-                        <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available at {{ $pdfPattern }}"> <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }} </a>
-                      {{- end }}
-                    {{ end }}
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td>English (US) ({{ $guidePage.Date.Format "January 2006" }}) - {{ i18n "download_official_current_version" . }}</td>
-                <td>
-                  {{- $creators := .Site.GetPage "/creators" }}
-                  {{- $creatorPages := $creators.Pages }}
-                  {{- range $index, $creator := $creatorPages }}
-                    {{- if $index }},{{ end }}
-                    {{- if gt (len $creatorPages) 1 }}{{ if eq $index (sub (len $creatorPages) 1) }}&{{ end }}{{ end }}
-                    <a href="{{ $creator.Permalink }}" class="text-decoration-none">{{ $creator.Title }}</a>
-                  {{- end }}
-                </td>
-                <td>
-                  <div class="d-flex gap-2">
-                    <!-- Online Reading Link -->
-                    {{ if $isComingSoon }}
-                      <a href="#" class="btn btn-outline-secondary btn-sm disabled">{{ i18n "read_online_action" . }}</a>
-                    {{ else }}
-                      {{- $englishGuidePage := .Site.GetPage "/guide" }}
-                      <a href="{{ $englishGuidePage.Permalink }}" class="btn btn-outline-secondary btn-sm">
-                        <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
-                      </a>
-                    {{ end }}
-                    <!-- PDF Download Link -->
-                    {{ if $isComingSoon }}
-                      <a href="#" class="btn btn-primary btn-sm disabled">{{ i18n "download_coming_soon" . }}</a>
-                    {{ else }}
-                      {{- $pdfPattern := printf "pdf/*.en-us.pdf" }}
+        <!-- Table Headers (visible on larger screens) -->
+        <div class="d-none d-md-block mb-3">
+          <div class="row fw-bold text-muted border-bottom pb-2">
+            <div class="col-md-4">{{ i18n "download_table_language" . }}</div>
+            <div class="col-md-4">{{ i18n "download_table_written_by" . }}</div>
+            <div class="col-md-4">{{ i18n "download_table_action" . }}</div>
+          </div>
+        </div>
 
-                      {{- $pdfResource := $guidePage.Resources.GetMatch $pdfPattern }}
-                      {{- if $pdfResource }}
-                        <a href="{{ $pdfResource.RelPermalink }}" class="btn btn-primary btn-sm pdf-download" download data-language="English (US)" data-language-code="en-us" data-type="Official" data-filename="{{ $pdfResource.Name }}">
-                          <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" . }}
-                        </a>
-                      {{- else }}
-                        <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available at {{ $pdfPattern }}"> <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }} </a>
-                      {{- end }}
-                    {{ end }}
-                  </div>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+        <!-- Official Version Cards/Rows -->
+        <div class="mb-5">
+          <!-- Current Language Version -->
+          <div class="card mb-3 d-md-none">
+            <div class="card-body">
+              <h6 class="card-title mb-2">
+                {{ .Site.Language.LanguageName }} ({{ $guidePage.Date.Format "January 2006" }}) -
+                {{ i18n "download_official_current_version" . }}
+              </h6>
+              <p class="card-text text-muted mb-3">
+                <small>{{ i18n "download_table_written_by" . }}:</small><br />
+                {{- $creators := .Site.GetPage "/creators" }}
+                {{- $creatorPages := $creators.Pages }}
+                {{- range $index, $creator := $creatorPages }}
+                  {{- if $index }},{{ end }}
+                  {{- if gt (len $creatorPages) 1 }}{{ if eq $index (sub (len $creatorPages) 1) }}&nbsp;{{ end }}{{ end }}
+                  <a href="{{ $creator.Permalink }}" class="text-decoration-none">{{ $creator.Title }}</a>
+                {{- end }}
+              </p>
+              <div class="d-flex gap-2 flex-wrap">
+                <!-- Online Reading Link -->
+                {{ if $isComingSoon }}
+                  <a href="#" class="btn btn-outline-secondary btn-sm disabled">{{ i18n "read_online_action" . }}</a>
+                {{ else }}
+                  <a href="{{ $guidePage.Permalink }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                  </a>
+                {{ end }}
+                <!-- PDF Download Link -->
+                {{ if $isComingSoon }}
+                  <a href="#" class="btn btn-primary btn-sm disabled">{{ i18n "download_coming_soon" . }}</a>
+                {{ else }}
+                  {{- $pdfPattern := printf "pdf/*.en.pdf" }}
+                  {{- $pdfResource := $guidePage.Resources.GetMatch $pdfPattern }}
+                  {{- if $pdfResource }}
+                    <a href="{{ $pdfResource.RelPermalink }}" class="btn btn-primary btn-sm pdf-download" download data-language="English" data-language-code="en" data-type="Official" data-filename="{{ $pdfResource.Name }}">
+                      <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" . }}
+                    </a>
+                  {{- else }}
+                    <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available at {{ $pdfPattern }}"> <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }} </a>
+                  {{- end }}
+                {{ end }}
+              </div>
+            </div>
+          </div>
+
+          <!-- Current Language Version - Desktop Row -->
+          <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
+            <div class="col-md-4">
+              {{ .Site.Language.LanguageName }} ({{ $guidePage.Date.Format "January 2006" }}) -
+              {{ i18n "download_official_current_version" . }}
+            </div>
+            <div class="col-md-4">
+              {{- $creators := .Site.GetPage "/creators" }}
+              {{- $creatorPages := $creators.Pages }}
+              {{- range $index, $creator := $creatorPages }}
+                {{- if $index }},{{ end }}
+                {{- if gt (len $creatorPages) 1 }}{{ if eq $index (sub (len $creatorPages) 1) }}&nbsp;{{ end }}{{ end }}
+                <a href="{{ $creator.Permalink }}" class="text-decoration-none">{{ $creator.Title }}</a>
+              {{- end }}
+            </div>
+            <div class="col-md-4">
+              <div class="d-flex gap-2">
+                <!-- Online Reading Link -->
+                {{ if $isComingSoon }}
+                  <a href="#" class="btn btn-outline-secondary btn-sm disabled">{{ i18n "read_online_action" . }}</a>
+                {{ else }}
+                  <a href="{{ $guidePage.Permalink }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                  </a>
+                {{ end }}
+                <!-- PDF Download Link -->
+                {{ if $isComingSoon }}
+                  <a href="#" class="btn btn-primary btn-sm disabled">{{ i18n "download_coming_soon" . }}</a>
+                {{ else }}
+                  {{- $pdfPattern := printf "pdf/*.en.pdf" }}
+                  {{- $pdfResource := $guidePage.Resources.GetMatch $pdfPattern }}
+                  {{- if $pdfResource }}
+                    <a href="{{ $pdfResource.RelPermalink }}" class="btn btn-primary btn-sm pdf-download" download data-language="English" data-language-code="en" data-type="Official" data-filename="{{ $pdfResource.Name }}">
+                      <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" . }}
+                    </a>
+                  {{- else }}
+                    <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available at {{ $pdfPattern }}"> <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }} </a>
+                  {{- end }}
+                {{ end }}
+              </div>
+            </div>
+          </div>
+
+          <!-- English (US) Version - Mobile Card -->
+          <div class="card mb-3 d-md-none">
+            <div class="card-body">
+              <h6 class="card-title mb-2">
+                English (US) ({{ $guidePage.Date.Format "January 2006" }}) -
+                {{ i18n "download_official_current_version" . }}
+              </h6>
+              <p class="card-text text-muted mb-3">
+                <small>{{ i18n "download_table_written_by" . }}:</small><br />
+                {{- $creators := .Site.GetPage "/creators" }}
+                {{- $creatorPages := $creators.Pages }}
+                {{- range $index, $creator := $creatorPages }}
+                  {{- if $index }},{{ end }}
+                  {{- if gt (len $creatorPages) 1 }}{{ if eq $index (sub (len $creatorPages) 1) }}&nbsp;{{ end }}{{ end }}
+                  <a href="{{ $creator.Permalink }}" class="text-decoration-none">{{ $creator.Title }}</a>
+                {{- end }}
+              </p>
+              <div class="d-flex gap-2 flex-wrap">
+                <!-- Online Reading Link -->
+                {{ if $isComingSoon }}
+                  <a href="#" class="btn btn-outline-secondary btn-sm disabled">{{ i18n "read_online_action" . }}</a>
+                {{ else }}
+                  {{- $englishGuidePage := .Site.GetPage "/guide" }}
+                  <a href="{{ $englishGuidePage.Permalink }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                  </a>
+                {{ end }}
+                <!-- PDF Download Link -->
+                {{ if $isComingSoon }}
+                  <a href="#" class="btn btn-primary btn-sm disabled">{{ i18n "download_coming_soon" . }}</a>
+                {{ else }}
+                  {{- $pdfPattern := printf "pdf/*.en-us.pdf" }}
+                  {{- $pdfResource := $guidePage.Resources.GetMatch $pdfPattern }}
+                  {{- if $pdfResource }}
+                    <a href="{{ $pdfResource.RelPermalink }}" class="btn btn-primary btn-sm pdf-download" download data-language="English (US)" data-language-code="en-us" data-type="Official" data-filename="{{ $pdfResource.Name }}">
+                      <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" . }}
+                    </a>
+                  {{- else }}
+                    <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available at {{ $pdfPattern }}"> <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }} </a>
+                  {{- end }}
+                {{ end }}
+              </div>
+            </div>
+          </div>
+
+          <!-- English (US) Version - Desktop Row -->
+          <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
+            <div class="col-md-4">
+              English (US) ({{ $guidePage.Date.Format "January 2006" }}) -
+              {{ i18n "download_official_current_version" . }}
+            </div>
+            <div class="col-md-4">
+              {{- $creators := .Site.GetPage "/creators" }}
+              {{- $creatorPages := $creators.Pages }}
+              {{- range $index, $creator := $creatorPages }}
+                {{- if $index }},{{ end }}
+                {{- if gt (len $creatorPages) 1 }}{{ if eq $index (sub (len $creatorPages) 1) }}&nbsp;{{ end }}{{ end }}
+                <a href="{{ $creator.Permalink }}" class="text-decoration-none">{{ $creator.Title }}</a>
+              {{- end }}
+            </div>
+            <div class="col-md-4">
+              <div class="d-flex gap-2">
+                <!-- Online Reading Link -->
+                {{ if $isComingSoon }}
+                  <a href="#" class="btn btn-outline-secondary btn-sm disabled">{{ i18n "read_online_action" . }}</a>
+                {{ else }}
+                  {{- $englishGuidePage := .Site.GetPage "/guide" }}
+                  <a href="{{ $englishGuidePage.Permalink }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                  </a>
+                {{ end }}
+                <!-- PDF Download Link -->
+                {{ if $isComingSoon }}
+                  <a href="#" class="btn btn-primary btn-sm disabled">{{ i18n "download_coming_soon" . }}</a>
+                {{ else }}
+                  {{- $pdfPattern := printf "pdf/*.en-us.pdf" }}
+                  {{- $pdfResource := $guidePage.Resources.GetMatch $pdfPattern }}
+                  {{- if $pdfResource }}
+                    <a href="{{ $pdfResource.RelPermalink }}" class="btn btn-primary btn-sm pdf-download" download data-language="English (US)" data-language-code="en-us" data-type="Official" data-filename="{{ $pdfResource.Name }}">
+                      <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" . }}
+                    </a>
+                  {{- else }}
+                    <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available at {{ $pdfPattern }}"> <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }} </a>
+                  {{- end }}
+                {{ end }}
+              </div>
+            </div>
+          </div>
         </div>
         <!-- Community Translations -->
         <h2 class="mb-3">{{ i18n "download_community_translations" . }}</h2>
@@ -124,86 +220,160 @@
             {{ i18n "download_older_translations_notice" . }}
           </small>
         </p>
-        <div class="table-responsive">
-          <table class="table table-striped">
-            <thead>
-              <tr>
-                <th scope="col">{{ i18n "download_table_language" . }}</th>
-                <th scope="col">{{ i18n "download_table_translations_by" . }}</th>
-                <th scope="col">{{ i18n "download_table_action" . }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {{- $basePage := site.GetPage "guide" }}
-              {{- range $basePage.AllTranslations }}
-                {{- if ne .Language.Lang "en" }}
-                  <tr>
-                    <td>
-                      {{ .Language.LanguageName }}
-                      {{- if .Date }}
-                        ({{ .Date.Format "January 2006" }})
-                      {{- else }}
-                        ({{ $guidePage.Date.Format "January 2006" }})
-                      {{- end }}
-                    </td>
-                    <td>
-                      {{- if .Params.contributors }}
-                        {{- range $index, $contributor := .Params.contributors }}
-                          {{- if $index }},{{ end }}
-                          {{- if $contributor.link }}
-                            <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
-                              {{ $contributor.name }}
-                              <i class="fa-solid fa-external-link-alt ms-1"></i>
-                            </a>
-                          {{- else }}
+
+        <!-- Table Headers (visible on larger screens) -->
+        <div class="d-none d-md-block mb-3">
+          <div class="row fw-bold text-muted border-bottom pb-2">
+            <div class="col-md-4">{{ i18n "download_table_language" . }}</div>
+            <div class="col-md-4">{{ i18n "download_table_translations_by" . }}</div>
+            <div class="col-md-4">{{ i18n "download_table_action" . }}</div>
+          </div>
+        </div>
+
+        <!-- Community Translation Cards/Rows -->
+        <div class="mb-4">
+          {{- $basePage := site.GetPage "guide" }}
+          {{- range $basePage.AllTranslations }}
+            {{- if ne .Language.Lang "en" }}
+              <!-- Mobile Card -->
+              <div class="card mb-3 d-md-none">
+                <div class="card-body">
+                  <h6 class="card-title mb-2">
+                    {{ .Language.LanguageName }}
+                    {{- if .Date }}
+                      ({{ .Date.Format "January 2006" }})
+                    {{- else }}
+                      ({{ $guidePage.Date.Format "January 2006" }})
+                    {{- end }}
+                  </h6>
+                  <p class="card-text text-muted mb-3">
+                    <small>{{ i18n "download_table_translations_by" . }}:</small><br />
+                    {{- if .Params.contributors }}
+                      {{- range $index, $contributor := .Params.contributors }}
+                        {{- if $index }},{{ end }}
+                        {{- if $contributor.link }}
+                          <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
                             {{ $contributor.name }}
-                          {{- end }}
-                        {{- end }}
-                      {{- else }}
-                        {{ i18n "download_community_contributors" . }}
-                      {{- end }}
-                    </td>
-                    <td>
-                      <div class="d-flex gap-2">
-                        <!-- Online Reading Link -->
-                        <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
-                          <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
-                        </a>
-                        <!-- PDF Download Link -->
-                        {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
-                        {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
-                        {{- if $pdfResource }}
-                          <a
-                            href="{{ $pdfResource.RelPermalink }}"
-                            class="btn btn-primary btn-sm pdf-download"
-                            download
-                            data-language="{{ .Language.LanguageName }}"
-                            data-language-code="{{ .Language.Lang }}"
-                            data-type="Translation"
-                            data-filename="{{ $pdfResource.Name }}">
-                            <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
+                            <i class="fa-solid fa-external-link-alt ms-1"></i>
                           </a>
                         {{- else }}
-                          <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
-                            <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
-                          </a>
+                          {{ $contributor.name }}
                         {{- end }}
-                      </div>
-                    </td>
-                  </tr>
-                {{- end }}
-              {{- end }}
-              <!-- Add Translation Row -->
-              <tr class="table-light">
-                <td colspan="2"><strong>{{ i18n "download_missing_language" . }}</strong> {{ i18n "download_contribute_translation" . }}</td>
-                <td>
-                  <a href="{{ .Site.Params.githubUrl }}/issues/new?template=new-translation.yml" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
-                    <i class="fa-solid fa-plus me-1"></i>{{ i18n "download_add_translation" . }}
-                  </a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                      {{- end }}
+                    {{- else }}
+                      {{ i18n "download_community_contributors" . }}
+                    {{- end }}
+                  </p>
+                  <div class="d-flex gap-2 flex-wrap">
+                    <!-- Online Reading Link -->
+                    <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
+                      <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                    </a>
+                    <!-- PDF Download Link -->
+                    {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
+                    {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
+                    {{- if $pdfResource }}
+                      <a
+                        href="{{ $pdfResource.RelPermalink }}"
+                        class="btn btn-primary btn-sm pdf-download"
+                        download
+                        data-language="{{ .Language.LanguageName }}"
+                        data-language-code="{{ .Language.Lang }}"
+                        data-type="Translation"
+                        data-filename="{{ $pdfResource.Name }}">
+                        <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
+                      </a>
+                    {{- else }}
+                      <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
+                        <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
+                      </a>
+                    {{- end }}
+                  </div>
+                </div>
+              </div>
+
+              <!-- Desktop Row -->
+              <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
+                <div class="col-md-4">
+                  {{ .Language.LanguageName }}
+                  {{- if .Date }}
+                    ({{ .Date.Format "January 2006" }})
+                  {{- else }}
+                    ({{ $guidePage.Date.Format "January 2006" }})
+                  {{- end }}
+                </div>
+                <div class="col-md-4">
+                  {{- if .Params.contributors }}
+                    {{- range $index, $contributor := .Params.contributors }}
+                      {{- if $index }},{{ end }}
+                      {{- if $contributor.link }}
+                        <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
+                          {{ $contributor.name }}
+                          <i class="fa-solid fa-external-link-alt ms-1"></i>
+                        </a>
+                      {{- else }}
+                        {{ $contributor.name }}
+                      {{- end }}
+                    {{- end }}
+                  {{- else }}
+                    {{ i18n "download_community_contributors" . }}
+                  {{- end }}
+                </div>
+                <div class="col-md-4">
+                  <div class="d-flex gap-2">
+                    <!-- Online Reading Link -->
+                    <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
+                      <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                    </a>
+                    <!-- PDF Download Link -->
+                    {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
+                    {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
+                    {{- if $pdfResource }}
+                      <a
+                        href="{{ $pdfResource.RelPermalink }}"
+                        class="btn btn-primary btn-sm pdf-download"
+                        download
+                        data-language="{{ .Language.LanguageName }}"
+                        data-language-code="{{ .Language.Lang }}"
+                        data-type="Translation"
+                        data-filename="{{ $pdfResource.Name }}">
+                        <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
+                      </a>
+                    {{- else }}
+                      <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
+                        <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
+                      </a>
+                    {{- end }}
+                  </div>
+                </div>
+              </div>
+            {{- end }}
+          {{- end }}
+
+
+          <!-- Add Translation Row/Card -->
+          <!-- Mobile Card -->
+          <div class="card mb-3 d-md-none bg-light">
+            <div class="card-body text-center">
+              <h6 class="card-title mb-2">{{ i18n "download_missing_language" . }}</h6>
+              <p class="card-text text-muted mb-3">{{ i18n "download_contribute_translation" . }}</p>
+              <a href="{{ .Site.Params.githubUrl }}/issues/new?template=new-translation.yml" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
+                <i class="fa-solid fa-plus me-1"></i>{{ i18n "download_add_translation" . }}
+              </a>
+            </div>
+          </div>
+
+          <!-- Desktop Row -->
+          <div class="row d-none d-md-flex align-items-center py-3 bg-light rounded">
+            <div class="col-md-8">
+              <strong>{{ i18n "download_missing_language" . }}</strong> {{ i18n "download_contribute_translation" . }}
+            </div>
+            <div class="col-md-4">
+              <a href="{{ .Site.Params.githubUrl }}/issues/new?template=new-translation.yml" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
+                <i class="fa-solid fa-plus me-1"></i>{{ i18n "download_add_translation" . }}
+              </a>
+            </div>
+          </div>
         </div>
 
         <!-- Preview Translations -->
@@ -237,42 +407,67 @@
                   </a>
                 </small>
               </p>
-              <div class="table-responsive mb-5">
-                <table class="table table-striped">
-                  <thead>
-                    <tr>
-                      <th scope="col">{{ i18n "download_table_language" . }}</th>
-                      <th scope="col">{{ i18n "download_table_status" . | default "Status" }}</th>
-                      <th scope="col">{{ i18n "download_table_action" . }}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {{- range $previewOnlyLanguages }}
-                      <tr>
-                        <td>{{ .name }}</td>
-                        <td>
-                          <span class="badge bg-warning text-dark">
-                            <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
-                          </span>
-                        </td>
-                        <td>
-                          <div class="d-flex gap-2">
-                            <!-- Preview Reading Link -->
-                            <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
-                              <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
-                            </a>
-                            <!-- Discussion Link -->
-                            {{- if .discussionId }}
-                              <a href="{{ $.Site.Params.githubUrl }}/discussions/{{ .discussionId }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
-                                <i class="fa-solid fa-comments me-1"></i>{{ i18n "download_discussion_action" . | default "Discussion" }}
-                              </a>
-                            {{- end }}
-                          </div>
-                        </td>
-                      </tr>
-                    {{- end }}
-                  </tbody>
-                </table>
+
+              <!-- Table Headers (visible on larger screens) -->
+              <div class="d-none d-md-block mb-3">
+                <div class="row fw-bold text-muted border-bottom pb-2">
+                  <div class="col-md-4">{{ i18n "download_table_language" . }}</div>
+                  <div class="col-md-4">{{ i18n "download_table_status" . | default "Status" }}</div>
+                  <div class="col-md-4">{{ i18n "download_table_action" . }}</div>
+                </div>
+              </div>
+
+              <!-- Preview Translation Cards/Rows -->
+              <div class="mb-5">
+                {{- range $previewOnlyLanguages }}
+                  <!-- Mobile Card -->
+                  <div class="card mb-3 d-md-none">
+                    <div class="card-body">
+                      <h6 class="card-title mb-2">{{ .name }}</h6>
+                      <p class="card-text mb-3">
+                        <span class="badge bg-warning text-dark">
+                          <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                        </span>
+                      </p>
+                      <div class="d-flex gap-2 flex-wrap">
+                        <!-- Preview Reading Link -->
+                        <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
+                          <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
+                        </a>
+                        <!-- Discussion Link -->
+                        {{- if .discussionId }}
+                          <a href="{{ $.Site.Params.githubUrl }}/discussions/{{ .discussionId }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
+                            <i class="fa-solid fa-comments me-1"></i>{{ i18n "download_discussion_action" . | default "Discussion" }}
+                          </a>
+                        {{- end }}
+                      </div>
+                    </div>
+                  </div>
+
+                  <!-- Desktop Row -->
+                  <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
+                    <div class="col-md-4">{{ .name }}</div>
+                    <div class="col-md-4">
+                      <span class="badge bg-warning text-dark">
+                        <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                      </span>
+                    </div>
+                    <div class="col-md-4">
+                      <div class="d-flex gap-2">
+                        <!-- Preview Reading Link -->
+                        <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
+                          <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
+                        </a>
+                        <!-- Discussion Link -->
+                        {{- if .discussionId }}
+                          <a href="{{ $.Site.Params.githubUrl }}/discussions/{{ .discussionId }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
+                            <i class="fa-solid fa-comments me-1"></i>{{ i18n "download_discussion_action" . | default "Discussion" }}
+                          </a>
+                        {{- end }}
+                      </div>
+                    </div>
+                  </div>
+                {{- end }}
               </div>
             {{- end }}
           {{- end }}


### PR DESCRIPTION
This pull request introduces functionality for handling "Preview Translations" in the multilingual site, including updates to configuration files, translation files, and layout templates. The changes aim to better manage and display translations that are in a preview state before being finalized. Below are the most important changes grouped by theme:

### Configuration Updates
* Added a `disabled: true` flag for Klingon (`tlh`), Persian (`fa`), and Dutch (`nl`) languages in `site/hugo.local.yaml` to mark them as disabled in the local configuration.

### Translation Enhancements
* Updated the `site/i18n/en.yaml`, `site/i18n/fa.yaml`, and `site/i18n/nl.yaml` files to include new keys and translations for "Preview Translations" functionality, such as `download_preview_translations`, `download_preview_description`, and `download_preview_action`. These translations support the new preview feature in multiple languages. [[1]](diffhunk://#diff-edf3e5566d707f973c44aac01937c9f60bd149c08df4495aebe2d77bc1ffb494L83-R105) [[2]](diffhunk://#diff-d47c3b2388aee402f3cfbf22e9d0283771f6146d7b83c8ae216699ccbff31a2aR145-R166) [[3]](diffhunk://#diff-e98b89456bc239018e350a9498b34110069c907e3d74628a14e972e286c56ed7R161-R182)

### Layout Modifications
* Modified `site/layouts/index.languages.json` to include a new `status` field for each language, defaulting to "active," enabling tracking of translation statuses.
* Updated `site/layouts/translations/list.html` to:
  - Exclude English (`en`) from the community translations table. [[1]](diffhunk://#diff-4c19347ee13d9768f428e0a8e851174453dbe5af7c18e2b28505f9f92bf5b2edR139) [[2]](diffhunk://#diff-4c19347ee13d9768f428e0a8e851174453dbe5af7c18e2b28505f9f92bf5b2edR195)
  - Add a new section for displaying "Preview Translations," including a table with language names, statuses, and actions (e.g., preview or discussion links). This section dynamically fetches data from a remote JSON file.

### Minor Adjustments
* Updated the Klingon language name in `site/hugo.yaml` to include "(reference)" for clarification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/126)
<!-- Reviewable:end -->
