### PR TITLE
Enable preview translations on all sites

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -61,6 +61,7 @@ params:
   supportEmail: "support@scrumexpansion.org"
   githubUrl: "https://github.com/ScrumGuides/ScrumGuide-ExpansionPack"
   previewSiteUrl: "https://agreeable-island-0c966e810-preview.centralus.6.azurestaticapps.net/"
+  productionSiteUrl: "https://scrumexpansion.org/"
 
 # Enable sitemap and robots.txt
 sitemap:

--- a/site/layouts/_partials/functions/get-translations.html
+++ b/site/layouts/_partials/functions/get-translations.html
@@ -1,0 +1,80 @@
+{{/* get-translations.html
+  Returns translations data based on type (community|preview)
+
+  @param type string - "community" or "preview"
+  @return slice - list of translation objects
+*/}}
+
+{{- $type := .type | default "community" }}
+{{- $translations := slice }}
+
+{{- if eq $type "community" }}
+  {{/* Get production languages */}}
+  {{- $productionLanguagesUrl := printf "%slanguages.json" .Site.Params.productionSiteUrl }}
+  {{- $productionLanguagesResponse := resources.GetRemote $productionLanguagesUrl }}
+  {{- $productionLanguageCodes := slice }}
+
+  {{- if $productionLanguagesResponse }}
+    {{- $productionLanguagesData := $productionLanguagesResponse | transform.Unmarshal }}
+    {{- if $productionLanguagesData.languages }}
+      {{- range $productionLanguagesData.languages }}
+        {{- $productionLanguageCodes = $productionLanguageCodes | append .code }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{/* If no production languages found, return empty slice (all will be preview) */}}
+  {{- if eq (len $productionLanguageCodes) 0 }}
+    {{- $translations = slice }}
+  {{- else }}
+    {{/* Return current site translations that are also in production */}}
+    {{- $basePage := site.GetPage "guide" }}
+    {{- range $basePage.AllTranslations }}
+      {{- if and (ne .Language.Lang "en") (in $productionLanguageCodes .Language.Lang) }}
+        {{- $translations = $translations | append . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+{{- else if eq $type "preview" }}
+  {{/* Get both production and preview languages */}}
+  {{- $productionLanguagesUrl := printf "%slanguages.json" .Site.Params.productionSiteUrl }}
+  {{- $productionLanguagesResponse := resources.GetRemote $productionLanguagesUrl }}
+  {{- $productionLanguageCodes := slice }}
+
+  {{- if $productionLanguagesResponse }}
+    {{- $productionLanguagesData := $productionLanguagesResponse | transform.Unmarshal }}
+    {{- if $productionLanguagesData.languages }}
+      {{- range $productionLanguagesData.languages }}
+        {{- $productionLanguageCodes = $productionLanguageCodes | append .code }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- $previewLanguagesUrl := printf "%slanguages.json" .Site.Params.previewSiteUrl }}
+  {{- $previewLanguagesResponse := resources.GetRemote $previewLanguagesUrl }}
+
+  {{- if $previewLanguagesResponse }}
+    {{- $previewLanguagesData := $previewLanguagesResponse | transform.Unmarshal }}
+    {{- if $previewLanguagesData.languages }}
+      {{- if eq (len $productionLanguageCodes) 0 }}
+        {{/* No production languages, return all preview languages except reference */}}
+        {{- range $previewLanguagesData.languages }}
+          {{- if ne .status "reference" }}
+            {{- $translations = $translations | append . }}
+          {{- end }}
+        {{- end }}
+      {{- else }}
+        {{/* Return preview languages that are NOT in production */}}
+        {{- range $previewLanguagesData.languages }}
+          {{- if and (not (in $productionLanguageCodes .code)) (ne .status "reference") }}
+            {{- $translations = $translations | append . }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+{{- end }}
+
+{{- return $translations -}}

--- a/site/layouts/translations/list.html
+++ b/site/layouts/translations/list.html
@@ -411,7 +411,7 @@
                   </p>
                   <div class="d-flex gap-2 flex-wrap">
                     <!-- Preview Reading Link -->
-                    <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
+                    <a href="/{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
                       <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
                     </a>
                     <!-- Discussion Link -->
@@ -435,7 +435,7 @@
                 <div class="col-md-4">
                   <div class="d-flex gap-2">
                     <!-- Preview Reading Link -->
-                    <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
+                    <a href="/{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
                       <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
                     </a>
                     <!-- Discussion Link -->

--- a/site/layouts/translations/list.html
+++ b/site/layouts/translations/list.html
@@ -232,77 +232,21 @@
 
         <!-- Community Translation Cards/Rows -->
         <div class="mb-4">
-          {{- $basePage := site.GetPage "guide" }}
-          {{- range $basePage.AllTranslations }}
-            {{- if ne .Language.Lang "en" }}
-              <!-- Mobile Card -->
-              <div class="card mb-3 d-md-none">
-                <div class="card-body">
-                  <h6 class="card-title mb-2">
-                    {{ .Language.LanguageName }}
-                    {{- if .Date }}
-                      ({{ .Date.Format "January 2006" }})
-                    {{- else }}
-                      ({{ $guidePage.Date.Format "January 2006" }})
-                    {{- end }}
-                  </h6>
-                  <p class="card-text text-muted mb-3">
-                    <small>{{ i18n "download_table_translations_by" . }}:</small><br />
-                    {{- if .Params.contributors }}
-                      {{- range $index, $contributor := .Params.contributors }}
-                        {{- if $index }},{{ end }}
-                        {{- if $contributor.link }}
-                          <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
-                            {{ $contributor.name }}
-                            <i class="fa-solid fa-external-link-alt ms-1"></i>
-                          </a>
-                        {{- else }}
-                          {{ $contributor.name }}
-                        {{- end }}
-                      {{- end }}
-                    {{- else }}
-                      {{ i18n "download_community_contributors" . }}
-                    {{- end }}
-                  </p>
-                  <div class="d-flex gap-2 flex-wrap">
-                    <!-- Online Reading Link -->
-                    <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
-                      <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
-                    </a>
-                    <!-- PDF Download Link -->
-                    {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
-                    {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
-                    {{- if $pdfResource }}
-                      <a
-                        href="{{ $pdfResource.RelPermalink }}"
-                        class="btn btn-primary btn-sm pdf-download"
-                        download
-                        data-language="{{ .Language.LanguageName }}"
-                        data-language-code="{{ .Language.Lang }}"
-                        data-type="Translation"
-                        data-filename="{{ $pdfResource.Name }}">
-                        <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
-                      </a>
-                    {{- else }}
-                      <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
-                        <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
-                      </a>
-                    {{- end }}
-                  </div>
-                </div>
-              </div>
-
-              <!-- Desktop Row -->
-              <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
-                <div class="col-md-4">
+          {{- $communityTranslations := partial "functions/get-translations.html" (dict "type" "community" "Site" .Site) }}
+          {{- range $communityTranslations }}
+            <!-- Mobile Card -->
+            <div class="card mb-3 d-md-none">
+              <div class="card-body">
+                <h6 class="card-title mb-2">
                   {{ .Language.LanguageName }}
                   {{- if .Date }}
                     ({{ .Date.Format "January 2006" }})
                   {{- else }}
                     ({{ $guidePage.Date.Format "January 2006" }})
                   {{- end }}
-                </div>
-                <div class="col-md-4">
+                </h6>
+                <p class="card-text text-muted mb-3">
+                  <small>{{ i18n "download_table_translations_by" . }}:</small><br />
                   {{- if .Params.contributors }}
                     {{- range $index, $contributor := .Params.contributors }}
                       {{- if $index }},{{ end }}
@@ -318,36 +262,90 @@
                   {{- else }}
                     {{ i18n "download_community_contributors" . }}
                   {{- end }}
-                </div>
-                <div class="col-md-4">
-                  <div class="d-flex gap-2">
-                    <!-- Online Reading Link -->
-                    <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
-                      <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                </p>
+                <div class="d-flex gap-2 flex-wrap">
+                  <!-- Online Reading Link -->
+                  <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                  </a>
+                  <!-- PDF Download Link -->
+                  {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
+                  {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
+                  {{- if $pdfResource }}
+                    <a
+                      href="{{ $pdfResource.RelPermalink }}"
+                      class="btn btn-primary btn-sm pdf-download"
+                      download
+                      data-language="{{ .Language.LanguageName }}"
+                      data-language-code="{{ .Language.Lang }}"
+                      data-type="Translation"
+                      data-filename="{{ $pdfResource.Name }}">
+                      <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
                     </a>
-                    <!-- PDF Download Link -->
-                    {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
-                    {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
-                    {{- if $pdfResource }}
-                      <a
-                        href="{{ $pdfResource.RelPermalink }}"
-                        class="btn btn-primary btn-sm pdf-download"
-                        download
-                        data-language="{{ .Language.LanguageName }}"
-                        data-language-code="{{ .Language.Lang }}"
-                        data-type="Translation"
-                        data-filename="{{ $pdfResource.Name }}">
-                        <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
-                      </a>
-                    {{- else }}
-                      <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
-                        <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
-                      </a>
-                    {{- end }}
-                  </div>
+                  {{- else }}
+                    <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
+                      <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
+                    </a>
+                  {{- end }}
                 </div>
               </div>
-            {{- end }}
+            </div>
+
+            <!-- Desktop Row -->
+            <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
+              <div class="col-md-4">
+                {{ .Language.LanguageName }}
+                {{- if .Date }}
+                  ({{ .Date.Format "January 2006" }})
+                {{- else }}
+                  ({{ $guidePage.Date.Format "January 2006" }})
+                {{- end }}
+              </div>
+              <div class="col-md-4">
+                {{- if .Params.contributors }}
+                  {{- range $index, $contributor := .Params.contributors }}
+                    {{- if $index }},{{ end }}
+                    {{- if $contributor.link }}
+                      <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
+                        {{ $contributor.name }}
+                        <i class="fa-solid fa-external-link-alt ms-1"></i>
+                      </a>
+                    {{- else }}
+                      {{ $contributor.name }}
+                    {{- end }}
+                  {{- end }}
+                {{- else }}
+                  {{ i18n "download_community_contributors" . }}
+                {{- end }}
+              </div>
+              <div class="col-md-4">
+                <div class="d-flex gap-2">
+                  <!-- Online Reading Link -->
+                  <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
+                    <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
+                  </a>
+                  <!-- PDF Download Link -->
+                  {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
+                  {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
+                  {{- if $pdfResource }}
+                    <a
+                      href="{{ $pdfResource.RelPermalink }}"
+                      class="btn btn-primary btn-sm pdf-download"
+                      download
+                      data-language="{{ .Language.LanguageName }}"
+                      data-language-code="{{ .Language.Lang }}"
+                      data-type="Translation"
+                      data-filename="{{ $pdfResource.Name }}">
+                      <i class="fa-solid fa-download me-1"></i>{{ i18n "download_button_text" }}
+                    </a>
+                  {{- else }}
+                    <a href="#" class="btn btn-primary btn-sm disabled" title="PDF not available">
+                      <i class="fa-solid fa-ban me-1"></i>{{ i18n "download_button_text" . }}
+                    </a>
+                  {{- end }}
+                </div>
+              </div>
+            </div>
           {{- end }}
 
 
@@ -377,100 +375,80 @@
         </div>
 
         <!-- Preview Translations -->
-        {{- $previewLanguagesUrl := printf "%slanguages.json" .Site.Params.previewSiteUrl }}
-        {{- $previewLanguagesResponse := resources.GetRemote $previewLanguagesUrl }}
-        {{- if $previewLanguagesResponse }}
-          {{- $previewLanguagesData := $previewLanguagesResponse | transform.Unmarshal }}
-          {{- if $previewLanguagesData.languages }}
-            {{- $currentLanguageCodes := slice }}
-            {{- $basePage := site.GetPage "guide" }}
-            {{- range $basePage.AllTranslations }}
-              {{- $currentLanguageCodes = $currentLanguageCodes | append .Language.Lang }}
-            {{- end }}
-            {{- $currentLanguageCodes = $currentLanguageCodes | append .Site.Language.Lang }}
+        {{- $previewTranslations := partial "functions/get-translations.html" (dict "type" "preview" "Site" .Site) }}
+        {{- if gt (len $previewTranslations) 0 }}
+          <h2 class="mb-3">{{ i18n "download_preview_translations" . | default "Preview Translations" }}</h2>
+          <p class="text-muted mb-3">
+            <small>
+              {{ i18n "download_preview_description" . | default "These translations are available in preview and will be moved to the main site once ready." }}
+              <a href="{{ .Site.Params.previewSiteUrl }}" target="_blank" rel="noopener" class="text-decoration-none">
+                {{ i18n "download_visit_preview" . | default "Visit preview site" }}
+                <i class="fa-solid fa-external-link-alt ms-1"></i>
+              </a>
+            </small>
+          </p>
 
-            {{- $previewOnlyLanguages := slice }}
-            {{- range $previewLanguagesData.languages }}
-              {{- if and (not (in $currentLanguageCodes .code)) (ne .status "reference") }}
-                {{- $previewOnlyLanguages = $previewOnlyLanguages | append . }}
-              {{- end }}
-            {{- end }}
+          <!-- Table Headers (visible on larger screens) -->
+          <div class="d-none d-md-block mb-3">
+            <div class="row fw-bold text-muted border-bottom pb-2">
+              <div class="col-md-4">{{ i18n "download_table_language" . }}</div>
+              <div class="col-md-4">{{ i18n "download_table_status" . | default "Status" }}</div>
+              <div class="col-md-4">{{ i18n "download_table_action" . }}</div>
+            </div>
+          </div>
 
-            {{- if gt (len $previewOnlyLanguages) 0 }}
-              <h2 class="mb-3">{{ i18n "download_preview_translations" . | default "Preview Translations" }}</h2>
-              <p class="text-muted mb-3">
-                <small>
-                  {{ i18n "download_preview_description" . | default "These translations are available in preview and will be moved to the main site once ready." }}
-                  <a href="{{ .Site.Params.previewSiteUrl }}" target="_blank" rel="noopener" class="text-decoration-none">
-                    {{ i18n "download_visit_preview" . | default "Visit preview site" }}
-                    <i class="fa-solid fa-external-link-alt ms-1"></i>
-                  </a>
-                </small>
-              </p>
-
-              <!-- Table Headers (visible on larger screens) -->
-              <div class="d-none d-md-block mb-3">
-                <div class="row fw-bold text-muted border-bottom pb-2">
-                  <div class="col-md-4">{{ i18n "download_table_language" . }}</div>
-                  <div class="col-md-4">{{ i18n "download_table_status" . | default "Status" }}</div>
-                  <div class="col-md-4">{{ i18n "download_table_action" . }}</div>
+          <!-- Preview Translation Cards/Rows -->
+          <div class="mb-5">
+            {{- range $previewTranslations }}
+              <!-- Mobile Card -->
+              <div class="card mb-3 d-md-none">
+                <div class="card-body">
+                  <h6 class="card-title mb-2">{{ .name }}</h6>
+                  <p class="card-text mb-3">
+                    <span class="badge bg-warning text-dark">
+                      <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                    </span>
+                  </p>
+                  <div class="d-flex gap-2 flex-wrap">
+                    <!-- Preview Reading Link -->
+                    <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
+                      <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
+                    </a>
+                    <!-- Discussion Link -->
+                    {{- if .discussionId }}
+                      <a href="{{ $.Site.Params.githubUrl }}/discussions/{{ .discussionId }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
+                        <i class="fa-solid fa-comments me-1"></i>{{ i18n "download_discussion_action" . | default "Discussion" }}
+                      </a>
+                    {{- end }}
+                  </div>
                 </div>
               </div>
 
-              <!-- Preview Translation Cards/Rows -->
-              <div class="mb-5">
-                {{- range $previewOnlyLanguages }}
-                  <!-- Mobile Card -->
-                  <div class="card mb-3 d-md-none">
-                    <div class="card-body">
-                      <h6 class="card-title mb-2">{{ .name }}</h6>
-                      <p class="card-text mb-3">
-                        <span class="badge bg-warning text-dark">
-                          <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
-                        </span>
-                      </p>
-                      <div class="d-flex gap-2 flex-wrap">
-                        <!-- Preview Reading Link -->
-                        <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
-                          <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
-                        </a>
-                        <!-- Discussion Link -->
-                        {{- if .discussionId }}
-                          <a href="{{ $.Site.Params.githubUrl }}/discussions/{{ .discussionId }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
-                            <i class="fa-solid fa-comments me-1"></i>{{ i18n "download_discussion_action" . | default "Discussion" }}
-                          </a>
-                        {{- end }}
-                      </div>
-                    </div>
+              <!-- Desktop Row -->
+              <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
+                <div class="col-md-4">{{ .name }}</div>
+                <div class="col-md-4">
+                  <span class="badge bg-warning text-dark">
+                    <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                  </span>
+                </div>
+                <div class="col-md-4">
+                  <div class="d-flex gap-2">
+                    <!-- Preview Reading Link -->
+                    <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
+                      <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
+                    </a>
+                    <!-- Discussion Link -->
+                    {{- if .discussionId }}
+                      <a href="{{ $.Site.Params.githubUrl }}/discussions/{{ .discussionId }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
+                        <i class="fa-solid fa-comments me-1"></i>{{ i18n "download_discussion_action" . | default "Discussion" }}
+                      </a>
+                    {{- end }}
                   </div>
-
-                  <!-- Desktop Row -->
-                  <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
-                    <div class="col-md-4">{{ .name }}</div>
-                    <div class="col-md-4">
-                      <span class="badge bg-warning text-dark">
-                        <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
-                      </span>
-                    </div>
-                    <div class="col-md-4">
-                      <div class="d-flex gap-2">
-                        <!-- Preview Reading Link -->
-                        <a href="{{ $.Site.Params.previewSiteUrl }}{{ .code }}/" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener">
-                          <i class="fa-solid fa-eye me-1"></i>{{ i18n "download_preview_action" . | default "Preview" }}
-                        </a>
-                        <!-- Discussion Link -->
-                        {{- if .discussionId }}
-                          <a href="{{ $.Site.Params.githubUrl }}/discussions/{{ .discussionId }}" class="btn btn-outline-primary btn-sm" target="_blank" rel="noopener">
-                            <i class="fa-solid fa-comments me-1"></i>{{ i18n "download_discussion_action" . | default "Discussion" }}
-                          </a>
-                        {{- end }}
-                      </div>
-                    </div>
-                  </div>
-                {{- end }}
+                </div>
               </div>
             {{- end }}
-          {{- end }}
+          </div>
         {{- end }}
 
       </div>


### PR DESCRIPTION
🌐 i18n(site): add production site URL parameter

- include productionSiteUrl in hugo.yaml for easier URL management

✨ feat(translations): add get-translations function

- create get-translations.html partial for dynamic translation fetching
- support both community and preview translation types

♻️ refactor(translations): update translation rendering logic

- utilize get-translations partial for community translations
- simplify preview translations rendering using get-translations partial

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/128)
<!-- Reviewable:end -->
