### PR TITLE
🐛 fix(translations): exclude English from preview languages

### DIFF
--- a/site/hugo.local.yaml
+++ b/site/hugo.local.yaml
@@ -8,4 +8,4 @@ disableAliases: true
 
 languages:
   tlh:
-    disabled: true
+    disabled: false

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -33,6 +33,7 @@ languages:
       description: pOlonyuS puqloD
       status: "reference"
       keywords: Yach
+      status: reference
   fa:
     languageName: فارسی
     weight: 2

--- a/site/layouts/_partials/functions/get-translations.html
+++ b/site/layouts/_partials/functions/get-translations.html
@@ -10,7 +10,7 @@
 
 {{- if eq $type "community" }}
   {{/* Get production languages */}}
-  {{- $productionLanguagesUrl := printf "%slanguages.json" .Site.Params.productionSiteUrl }}
+  {{- $productionLanguagesUrl := printf "%slanguages.json?v=%d" .Site.Params.productionSiteUrl now.Unix }}
   {{- $productionLanguagesResponse := resources.GetRemote $productionLanguagesUrl }}
   {{- $productionLanguageCodes := slice }}
 
@@ -20,25 +20,28 @@
       {{- range $productionLanguagesData.languages }}
         {{- $productionLanguageCodes = $productionLanguageCodes | append .code }}
       {{- end }}
-    {{- end }}
-  {{- end }}
 
-  {{/* If no production languages found, return empty slice (all will be preview) */}}
-  {{- if eq (len $productionLanguageCodes) 0 }}
-    {{- $translations = slice }}
-  {{- else }}
-    {{/* Return current site translations that are also in production */}}
-    {{- $basePage := site.GetPage "guide" }}
-    {{- range $basePage.AllTranslations }}
-      {{- if and (ne .Language.Lang "en") (in $productionLanguageCodes .Language.Lang) }}
-        {{- $translations = $translations | append . }}
+      {{/* Return production languages except English (and reference only in production environment) */}}
+      {{- range $productionLanguagesData.languages }}
+        {{- $shouldInclude := true }}
+        {{- if eq hugo.Environment "production" }}
+          {{- if eq .status "reference" }}
+            {{- $shouldInclude = false }}
+          {{- end }}
+        {{- end }}
+        {{- if eq .code "en" }}
+          {{- $shouldInclude = false }}
+        {{- end }}
+        {{- if $shouldInclude }}
+          {{- $translations = $translations | append . }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}
 
 {{- else if eq $type "preview" }}
   {{/* Get both production and preview languages */}}
-  {{- $productionLanguagesUrl := printf "%slanguages.json" .Site.Params.productionSiteUrl }}
+  {{- $productionLanguagesUrl := printf "%slanguages.json?v=%d" .Site.Params.productionSiteUrl now.Unix }}
   {{- $productionLanguagesResponse := resources.GetRemote $productionLanguagesUrl }}
   {{- $productionLanguageCodes := slice }}
 
@@ -51,23 +54,23 @@
     {{- end }}
   {{- end }}
 
-  {{- $previewLanguagesUrl := printf "%slanguages.json" .Site.Params.previewSiteUrl }}
+  {{- $previewLanguagesUrl := printf "%slanguages.json?v=%d" .Site.Params.previewSiteUrl now.Unix }}
   {{- $previewLanguagesResponse := resources.GetRemote $previewLanguagesUrl }}
 
   {{- if $previewLanguagesResponse }}
     {{- $previewLanguagesData := $previewLanguagesResponse | transform.Unmarshal }}
     {{- if $previewLanguagesData.languages }}
       {{- if eq (len $productionLanguageCodes) 0 }}
-        {{/* No production languages, return all preview languages except reference and English */}}
+        {{/* No production languages, return all preview languages except English and Klingon */}}
         {{- range $previewLanguagesData.languages }}
-          {{- if and (ne .status "reference") (ne .code "en") }}
+          {{- if ne .code "en" }}
             {{- $translations = $translations | append . }}
           {{- end }}
         {{- end }}
       {{- else }}
         {{/* Return preview languages that are NOT in production and NOT English */}}
         {{- range $previewLanguagesData.languages }}
-          {{- if and (not (in $productionLanguageCodes .code)) (ne .status "reference") (ne .code "en") }}
+          {{- if and (not (in $productionLanguageCodes .code)) (ne .code "en") }}
             {{- $translations = $translations | append . }}
           {{- end }}
         {{- end }}

--- a/site/layouts/_partials/functions/get-translations.html
+++ b/site/layouts/_partials/functions/get-translations.html
@@ -58,16 +58,16 @@
     {{- $previewLanguagesData := $previewLanguagesResponse | transform.Unmarshal }}
     {{- if $previewLanguagesData.languages }}
       {{- if eq (len $productionLanguageCodes) 0 }}
-        {{/* No production languages, return all preview languages except reference */}}
+        {{/* No production languages, return all preview languages except reference and English */}}
         {{- range $previewLanguagesData.languages }}
-          {{- if ne .status "reference" }}
+          {{- if and (ne .status "reference") (ne .code "en") }}
             {{- $translations = $translations | append . }}
           {{- end }}
         {{- end }}
       {{- else }}
-        {{/* Return preview languages that are NOT in production */}}
+        {{/* Return preview languages that are NOT in production and NOT English */}}
         {{- range $previewLanguagesData.languages }}
-          {{- if and (not (in $productionLanguageCodes .code)) (ne .status "reference") }}
+          {{- if and (not (in $productionLanguageCodes .code)) (ne .status "reference") (ne .code "en") }}
             {{- $translations = $translations | append . }}
           {{- end }}
         {{- end }}

--- a/site/layouts/translations/list.html
+++ b/site/layouts/translations/list.html
@@ -234,21 +234,23 @@
         <div class="mb-4">
           {{- $communityTranslations := partial "functions/get-translations.html" (dict "type" "community" "Site" .Site) }}
           {{- range $communityTranslations }}
+            {{- $basePage := .Site.GetPage "guide" }}
+            {{- $translationPage := $basePage.GetPage (printf "/%s/guide" .Language.Lang) | default $basePage }}
             <!-- Mobile Card -->
             <div class="card mb-3 d-md-none">
               <div class="card-body">
                 <h6 class="card-title mb-2">
                   {{ .Language.LanguageName }}
-                  {{- if .Date }}
-                    ({{ .Date.Format "January 2006" }})
+                  {{- if $translationPage.Date }}
+                    ({{ $translationPage.Date.Format "January 2006" }})
                   {{- else }}
                     ({{ $guidePage.Date.Format "January 2006" }})
                   {{- end }}
                 </h6>
                 <p class="card-text text-muted mb-3">
                   <small>{{ i18n "download_table_translations_by" . }}:</small><br />
-                  {{- if .Params.contributors }}
-                    {{- range $index, $contributor := .Params.contributors }}
+                  {{- if $translationPage.Params.contributors }}
+                    {{- range $index, $contributor := $translationPage.Params.contributors }}
                       {{- if $index }},{{ end }}
                       {{- if $contributor.link }}
                         <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
@@ -265,12 +267,12 @@
                 </p>
                 <div class="d-flex gap-2 flex-wrap">
                   <!-- Online Reading Link -->
-                  <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
+                  <a href="{{ $translationPage.Permalink }}" class="btn btn-outline-secondary btn-sm">
                     <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
                   </a>
                   <!-- PDF Download Link -->
                   {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
-                  {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
+                  {{- $pdfResource := $translationPage.Resources.GetMatch $pdfPattern }}
                   {{- if $pdfResource }}
                     <a
                       href="{{ $pdfResource.RelPermalink }}"
@@ -295,15 +297,15 @@
             <div class="row d-none d-md-flex align-items-center py-3 border-bottom">
               <div class="col-md-4">
                 {{ .Language.LanguageName }}
-                {{- if .Date }}
-                  ({{ .Date.Format "January 2006" }})
+                {{- if $translationPage.Date }}
+                  ({{ $translationPage.Date.Format "January 2006" }})
                 {{- else }}
                   ({{ $guidePage.Date.Format "January 2006" }})
                 {{- end }}
               </div>
               <div class="col-md-4">
-                {{- if .Params.contributors }}
-                  {{- range $index, $contributor := .Params.contributors }}
+                {{- if $translationPage.Params.contributors }}
+                  {{- range $index, $contributor := $translationPage.Params.contributors }}
                     {{- if $index }},{{ end }}
                     {{- if $contributor.link }}
                       <a href="{{ $contributor.link }}" target="_blank" rel="noopener" class="text-decoration-none">
@@ -321,12 +323,12 @@
               <div class="col-md-4">
                 <div class="d-flex gap-2">
                   <!-- Online Reading Link -->
-                  <a href="{{ .Permalink }}" class="btn btn-outline-secondary btn-sm">
+                  <a href="{{ $translationPage.Permalink }}" class="btn btn-outline-secondary btn-sm">
                     <i class="fa-solid fa-book-open me-1"></i>{{ i18n "read_online_action" . }}
                   </a>
                   <!-- PDF Download Link -->
                   {{- $pdfPattern := printf "pdf/*.%s.pdf" .Language.Lang }}
-                  {{- $pdfResource := .Resources.GetMatch $pdfPattern }}
+                  {{- $pdfResource := $translationPage.Resources.GetMatch $pdfPattern }}
                   {{- if $pdfResource }}
                     <a
                       href="{{ $pdfResource.RelPermalink }}"
@@ -406,7 +408,11 @@
                   <h6 class="card-title mb-2">{{ .name }}</h6>
                   <p class="card-text mb-3">
                     <span class="badge bg-warning text-dark">
-                      <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                      {{ if eq .status "reference" }}
+                        <i class="fa-solid fa-book-reader me-1"></i>{{ i18n "download_reference_status" . | default "Reference" }}
+                      {{ else }}
+                        <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                      {{- end }}
                     </span>
                   </p>
                   <div class="d-flex gap-2 flex-wrap">
@@ -429,7 +435,11 @@
                 <div class="col-md-4">{{ .name }}</div>
                 <div class="col-md-4">
                   <span class="badge bg-warning text-dark">
-                    <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                    {{ if eq .status "reference" }}
+                      <i class="fa-solid fa-book-reader me-1"></i>{{ i18n "download_reference_status" . | default "Reference" }}
+                    {{ else }}
+                      <i class="fa-solid fa-flask me-1"></i>{{ i18n "download_preview_status" . | default "In Preview" }}
+                    {{- end }}
                   </span>
                 </div>
                 <div class="col-md-4">


### PR DESCRIPTION
- modify condition to exclude English ('en') from preview languages when no production languages are present
- ensure English is not added to translations when comparing with production languages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/130)
<!-- Reviewable:end -->
