### PR TITLE
🌐 i18n(hugo): add German language configuration

### DIFF
--- a/site/hugo.production.yaml
+++ b/site/hugo.production.yaml
@@ -11,3 +11,5 @@ languages:
     disabled: true
   nl:
     disabled: true
+  de:
+    disabled: true


### PR DESCRIPTION
- add German language (de) to the Hugo production configuration
- initially set German language as disabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/136)
<!-- Reviewable:end -->
