### PR TITLE
fix/ Translation CoC inconsistencies

### DIFF
--- a/site/content/guide/index.de.md
+++ b/site/content/guide/index.de.md
@@ -73,22 +73,22 @@ Kurz gesagt basiert Scrum auf einer Umgebung, in der:
 
 1. Unterstützende Stakeholder, im Folgenden als „Supporter” bezeichnet, unter Anleitung und mit Unterstützung des Scrum Masters alles Notwendige tun, um die Einführung von Scrum proaktiv zu unterstützen und zu verbessern.
 2. Ein Produkt Owner das Produktziel festlegt, das für die Erfüllung des Stakeholder-Werts entscheidend ist.
-3. Das selbst-gemanagte Scrum-Team (49) die Auswahl der Arbeit definiert, verfeinert, und sie in wertvolle Ergebnisse verwandelt.
-4. Das Scrum-Team und die Stakeholder die Ergebnisse während des Sprints überprüfen und sie anpassen.
-5. Die Unterstützer dem Scrum-Team helfen, erfolgreich zu sein.
+3. Das selbst-gemanagte Scrum Team (49) die Auswahl der Arbeit definiert, verfeinert, und sie in wertvolle Ergebnisse verwandelt.
+4. Das Scrum Team und die Stakeholder die Ergebnisse während des Sprints überprüfen und sie anpassen.
+5. Die Unterstützer dem Scrum Team helfen, erfolgreich zu sein.
 6. _Zurück zum Anfang._
 
 Eine Release ist der Prozess, bei dem eine neue oder aktualisierte Version eines Produkts für Stakeholder (einschließlich, aber nicht beschränkt auf Kunden, Entscheidungsträger und Endnutzer) verfügbar gemacht wird. Sie markiert einen Wendepunkt im Entwicklungszyklus und stellt den Übergang des Produkts von der Entwicklung zur Verfügbarkeit für die Nutzung und die potenzielle Realisierung des Stakeholder-Werts dar.
 
 Scrum ist bewusst unvollständig. Anstatt detaillierte Prozesse vorzuschreiben, bietet es einen Rahmen, der Beziehungen und zielgerichtete Interaktionen leitet. Verschiedene Prozesse, Techniken und Methoden können Scrum ergänzen, ihre Anwendung hängt jedoch vom Kontext ab und variiert je nach Einsatzbereich von Scrum.
 
-Scrum lässt sich in bestehende Praktiken integrieren oder macht diese in einigen Fällen überflüssig oder nicht mehr zeitgemäß. Durch die transparente Bewertung der Effektivität des Scrum-Teams, der Unterstützer, des aktuellen Managements, der Arbeitsumgebung und der Techniken ermöglicht Scrum eine kontinuierliche Verbesserung.
+Scrum lässt sich in bestehende Praktiken integrieren oder macht diese in einigen Fällen überflüssig oder nicht mehr zeitgemäß. Durch die transparente Bewertung der Effektivität des Scrum Teams, der Unterstützer, des aktuellen Managements, der Arbeitsumgebung und der Techniken ermöglicht Scrum eine kontinuierliche Verbesserung.
 
 Im Kontext der Wissensarbeit wurde der Begriff Scrum, der aus dem Rugby-Spiel stammt, von Takeuchi und Nonaka (29) geprägt, um Teams zu beschreiben, die auf diese Weise arbeiteten und durch welche Wissen schnell im gesamten Unternehmen verbreitet wurde, um herausragende Produkte zu liefern.
 
 ## Unterstützende und ergänzende Theorie {#supporting-and-complementary-theory}
 
-Scrum basiert auf einem selbst-gemanagten Scrum-Team (49), Emergenz, Empirie (67) und Lean Thinking (63). Es stützt sich auf die folgenden unterstützenden und ergänzenden Theorien und Ideen:
+Scrum basiert auf einem selbst-gemanagten Scrum Team (49), Emergenz, Empirie (67) und Lean Thinking (63). Es stützt sich auf die folgenden unterstützenden und ergänzenden Theorien und Ideen:
 
 - Verantwortlichkeit,
 - Reduzierung von nicht wertschöpfenden Verschwendungen (einschließlich organisatorischer Ineffizienzen),
@@ -98,11 +98,11 @@ Scrum basiert auf einem selbst-gemanagten Scrum-Team (49), Emergenz, Empirie (67
 
 ### Komplexität – Argumente für Scrum {#complexity–the-case-for-scrum}
 
-Bei komplexen Aufgaben wie der Entwicklung von Produkten gibt es mehr Unbekanntes als Bekanntes, Fachwissen allein ist wertvoll, aber nicht ausreichend, und Ursache und Wirkung werden erst im Nachhinein klar. Komplexitätsdenken (30-35) liefert wertvolle Werkzeuge und Ideen und erleichtert Einsichten. Die Mitglieder des Scrum-Teams benötigen Zeit, um nachzudenken, sich gegenseitig zu helfen, Nacharbeiten zu leisten oder umzudenken. Kognitive Vielfalt und Empirie können dabei helfen, komplexe Aufgaben zu bewältigen.
+Bei komplexen Aufgaben wie der Entwicklung von Produkten gibt es mehr Unbekanntes als Bekanntes, Fachwissen allein ist wertvoll, aber nicht ausreichend, und Ursache und Wirkung werden erst im Nachhinein klar. Komplexitätsdenken (30-35) liefert wertvolle Werkzeuge und Ideen und erleichtert Einsichten. Die Mitglieder des Scrum Teams benötigen Zeit, um nachzudenken, sich gegenseitig zu helfen, Nacharbeiten zu leisten oder umzudenken. Kognitive Vielfalt und Empirie können dabei helfen, komplexe Aufgaben zu bewältigen.
 
 Alles, was als „bekannt” gilt, einschließlich des Marktes und der Stakeholder (einschließlich, aber nicht beschränkt auf Kunden), kann falsch sein. Einige Erwartungen, Bedürfnisse oder Wünsche entstehen oder verschwinden im Laufe der Zeit in ihrer relativen Bedeutung oder Dringlichkeit. Ein empirischer Ansatz bietet Mechanismen zum Testen von Annahmen sowie zur Überprüfung und Anpassung.
 
-Im Allgemeinen bleibt nichts für immer gleich. Das Scrum-Team befindet sich möglicherweise am Rande des Chaos und erforscht und arbeitet an etwas Unbekanntem, das noch nie zuvor gemacht wurde. Nach einer Weile, wenn es Muster und Heuristiken entdeckt, wird es weniger chaotisch und komplexer. Nach einer weiteren Weile nähert sich das Scrum-Team möglicherweise dem geordneten Raum, was nicht einfach, aber planbar ist. Oder es kann auch umgekehrt laufen. Es ist eine gute Praxis für das Scrum-Team, inne zu halten und zu reflektieren, ob es sich wirklich in dem Raum befindet, in dem es sich für die aktuelle Situation vermutet hat. Der entscheidende Punkt ist, dass die Produktentwicklung oft mit Unvorhersehbarkeiten zu tun hat und Scrum ein nützlicherer Ansatz sein kann als solche, die sich in der Illusion der Vorhersagbarkeit wiegen.
+Im Allgemeinen bleibt nichts für immer gleich. Das Scrum Team befindet sich möglicherweise am Rande des Chaos und erforscht und arbeitet an etwas Unbekanntem, das noch nie zuvor gemacht wurde. Nach einer Weile, wenn es Muster und Heuristiken entdeckt, wird es weniger chaotisch und komplexer. Nach einer weiteren Weile nähert sich das Scrum Team möglicherweise dem geordneten Raum, was nicht einfach, aber planbar ist. Oder es kann auch umgekehrt laufen. Es ist eine gute Praxis für das Scrum Team, inne zu halten und zu reflektieren, ob es sich wirklich in dem Raum befindet, in dem es sich für die aktuelle Situation vermutet hat. Der entscheidende Punkt ist, dass die Produktentwicklung oft mit Unvorhersehbarkeiten zu tun hat und Scrum ein nützlicherer Ansatz sein kann als solche, die sich in der Illusion der Vorhersagbarkeit wiegen.
 
 Die Chancen, die sich durch Inspektion und Anpassung des „Wer”, „Warum”, „Was”, „Wie”, „Wo” und „Wann” ergeben, sind vielfältig. Es ist wichtig, das, was nicht funktioniert, abzuschwächen und das, was funktioniert, zu verstärken. Transparenz, Inspektion und Anpassung an festgelegte Ziele, gestützt auf Ergebnisfeedback (und unbeabsichtigte Folgen), sorgen für Wertschöpfung, Erkenntnisse, Risiken und hinterfragte Annahmen; dies kann zu kontinuierlicher Verbesserung führen.
 
@@ -112,21 +112,21 @@ Schaffen Sie Vertrauen durch ein selbst-gemanagtes Team, Überprüfung, Anpassun
 
 Emergenz (71) ist, wenn aus Interaktionen innerhalb komplexer (30-35) Systeme sinnvolle Muster oder Verhaltensweisen entstehen – Muster, die man nicht allein durch Betrachten der einzelnen Teile vorhersagen kann. In Scrum wird Emergenz nicht streng kontrolliert, sondern durch fördernde Rahmenbedingungen wie Zeitboxen, Rollen und Feedback-Schleifen gesteuert, die die Voraussetzungen für Selbstmanagement und Anpassungsfähigkeit schaffen, ohne genaue Ergebnisse vorzugeben. Diese Strukturen wirken wie „Inseln” in einem Meer der Unvorhersehbarkeit, ähnlich wie physikalische Systeme spontan organisierte Muster inmitten von Zufälligkeiten bilden können, wie in Stephen Wolframs Arbeit (38) beschrieben. Der Schlüssel liegt darin, dass die Struktur in Scrum den Teams genügend Orientierung bietet, um sich selbst zu managen und neue Lösungen zu entwickeln, anstatt jedes Detail vorzuschreiben.
 
-Scrum-Teams, die als komplexe adaptive Systeme arbeiten, werden durch kurze, parallele, fehlertolerante (safe-to-fail) Experimente und kontinuierliches Feedback beeinflusst, nicht gelenkt. Muster (53) wie „Swarming”, „Stable Teams” und „Kaizen” helfen dabei, emergentes Verhalten zu identifizieren und zu formen. Anstatt Ergebnisse zu erzwingen, ermöglicht Scrum dem Scrum-Team, wünschenswerte Muster zu entdecken, darunter innovative Lösungen oder neue Arbeitsweisen, und diese zu verstärken, während unhilfreiche Muster abgeschwächt werden.
+Scrum Teams, die als komplexe adaptive Systeme arbeiten, werden durch kurze, parallele, fehlertolerante (safe-to-fail) Experimente und kontinuierliches Feedback beeinflusst, nicht gelenkt. Muster (53) wie „Swarming”, „Stable Teams” und „Kaizen” helfen dabei, emergentes Verhalten zu identifizieren und zu formen. Anstatt Ergebnisse zu erzwingen, ermöglicht Scrum dem Scrum Team, wünschenswerte Muster zu entdecken, darunter innovative Lösungen oder neue Arbeitsweisen, und diese zu verstärken, während unhilfreiche Muster abgeschwächt werden.
 
 Dieser Ansatz erkennt an, dass Selbstmanagement (49) nicht von oben nach unten gestaltet werden kann, sondern in der richtigen Umgebung entdeckt werden muss – einer Umgebung, die sich sinnvoll, kohärent und lebendig anfühlt, ganz im Sinne von Christopher Alexanders „Quality Without a Name” (39). Letztendlich betrachtet Scrum Emergenz nicht als ein Risiko, das es zu beseitigen gilt, sondern als eine Kraft, die für Spitzenleistungen in der Produktentwicklung gefördert werden muss.
 
-### Selbst-gemanagtes Scrum-Team {#self-managing-scrum-team}
+### Selbst-gemanagtes Scrum Team {#self-managing-Scrum Team}
 
-Ein selbst-gemanagtes (49) Scrum-Team überprüft, ob es auf dem richtigen Weg ist, ergreift Maßnahmen, wenn dies nicht der Fall ist, entscheidet, wie gearbeitet wird, löst Konflikte innerhalb des Scrum-Teams und behebt Probleme im Scrum-Team. Das bedeutet, dass Manager (111), sofern sie Teil der Landschaft sind, dem Scrum-Team in der Regel nicht sagen, was es zu tun hat, oder entscheiden, welches Scrum-Team-Mitglied zur Behebung von Problemen direkt oder indirekt zur Seite genommen werden muss. Wenn es Manager gibt, ist es in der Regel besser, wenn sie Führungsqualitäten zeigen.
+Ein selbst-gemanagtes (49) Scrum Team überprüft, ob es auf dem richtigen Weg ist, ergreift Maßnahmen, wenn dies nicht der Fall ist, entscheidet, wie gearbeitet wird, löst Konflikte innerhalb des Scrum Teams und behebt Probleme im Scrum Team. Das bedeutet, dass Manager (111), sofern sie Teil der Landschaft sind, dem Scrum Team in der Regel nicht sagen, was es zu tun hat, oder entscheiden, welches Scrum Team-Mitglied zur Behebung von Problemen direkt oder indirekt zur Seite genommen werden muss. Wenn es Manager gibt, ist es in der Regel besser, wenn sie Führungsqualitäten zeigen.
 
-Selbst-gemanagte, wertorientiert organisierte Scrum-Teams sind entscheidend für kreative Problemlösungen und das Erfassen von Emergenzen; die Abhängigkeit von nicht selbst-gemanagten Scrum-Teams behindert die Fähigkeit, mit Komplexität umzugehen (30-35). Selbst-gemanagte Scrum-Teams (49) sind nicht mit individueller Selbstorganisation zu verwechseln. Es ist das nahtlose Zusammenspiel, das ein großartiges Team entstehen lässt. Die Moderation der Teamautonomie und effizientere Entscheidungsfindung innerhalb einer nicht-hierarchischen Struktur könnte Scrum-Teams dabei helfen, ihre Selbstorganisation zu verbessern.
+Selbst-gemanagte, wertorientiert organisierte Scrum Teams sind entscheidend für kreative Problemlösungen und das Erfassen von Emergenzen; die Abhängigkeit von nicht selbst-gemanagten Scrum Teams behindert die Fähigkeit, mit Komplexität umzugehen (30-35). Selbst-gemanagte Scrum Teams (49) sind nicht mit individueller Selbstorganisation zu verwechseln. Es ist das nahtlose Zusammenspiel, das ein großartiges Team entstehen lässt. Die Moderation der Teamautonomie und effizientere Entscheidungsfindung innerhalb einer nicht-hierarchischen Struktur könnte Scrum Teams dabei helfen, ihre Selbstorganisation zu verbessern.
 
 ### Professionalität {#professionalism}
 
 Professionalität bedeutet, nach Spitzenleistungen zu streben und gemeinsam daran zu arbeiten, auf respektvolle, transparente und verantwortungsbewusste Weise einen Mehrwert zu schaffen. Professionell zu sein bedeutet, dass man bestimmte Dinge immer tut und andere niemals, unabhängig von den Umständen.
 
-Professionell zu sein bedeutet, die volle Verantwortung für das Produkt zu übernehmen, von der Konzeption bis zum Ende seines Lebenszyklus. Professionalität umfasst auch die Wartung, oft in Form von Betriebsabläufen, und bietet den Produktentwicklern hervorragende Möglichkeiten, aus den Ergebnissen der technischen Arbeit zu lernen.
+Professionell zu sein bedeutet, die volle Verantwortung für das Produkt zu übernehmen, von der Konzeption bis zum Ende seines Lebenszyklus. Professionalität umfasst auch die Wartung, oft in Form von Betriebsabläufen, und bietet den Product Developern hervorragende Möglichkeiten, aus den Ergebnissen der technischen Arbeit zu lernen.
 
 Im Kontext der Softwareentwicklung umfasst Professionalität unter anderem technische Exzellenz (112). Technische Exzellenz umfasst unter anderem Folgendes: Spezifikation anhand von Beispielen (specification by examples), Clean Code, Unit-Tests, testgetriebene Entwicklung, Testautomatisierung, kontinuierliche Integration (continuous integration), kontinuierliche Lieferung (continuous delivery), Architektur und Design, Abnahmetests sowie die gezielte und bewusste Berücksichtigung von Tests.
 
@@ -138,15 +138,15 @@ Im Kontext der Softwareentwicklung umfasst Professionalität unter anderem techn
 
 Empirie (67) ist das Prinzip, Entscheidungen auf der Grundlage objektiver oder beobachtbarer Beweise in Lernzyklen zu treffen, die oft explorativ sind. Er kann in Situationen nützlich sein, in denen mehr als nur Fachwissen erforderlich ist. Scrum basiert auf Empirie. Entscheidungen werden auf der Grundlage von Beweisen oder Beobachtungen getroffen. Ein empirischer Ansatz umfasst kontinuierliche Beobachtungen, Theorieentwicklung/Verfeinerung, Operationalisierung und Tests/Modifikationen, um effektive Feedback-Schleifen zu etablieren.
 
-Empirie kann Scrum-Teams dabei helfen, etwas zu liefern, das Stakeholder als wertvoll erachten, wenn das „Was” oder „Wie” ungewiss ist. Bei Scrum geht es darum, das Unwahrscheinliche wahrscheinlich zu machen, indem Wert entdeckt, geliefert und realisiert wird; dies umfasst oft, ist aber nicht beschränkt auf Kompromisse oder Experimente. Experimente basieren in der Regel auf überprüfbaren Hypothesen, manchmal aber auch auf fundierten Vermutungen. Eine wichtige Reaktion auf Experimente ist eine evidenzbasierte Entscheidungsfindung.
+Empirie kann Scrum Teams dabei helfen, etwas zu liefern, das Stakeholder als wertvoll erachten, wenn das „Was” oder „Wie” ungewiss ist. Bei Scrum geht es darum, das Unwahrscheinliche wahrscheinlich zu machen, indem Wert entdeckt, geliefert und realisiert wird; dies umfasst oft, ist aber nicht beschränkt auf Kompromisse oder Experimente. Experimente basieren in der Regel auf überprüfbaren Hypothesen, manchmal aber auch auf fundierten Vermutungen. Eine wichtige Reaktion auf Experimente ist eine evidenzbasierte Entscheidungsfindung.
 
-Pausen und Reflexion verbinden Elemente des Empirie und des Lean-Denkens, schaffen die Grundlage für Transparenz, Überprüfung und Anpassung an das Produktziel und helfen dem Scrum-Team und den Unterstützern, sich selbst und ihr Umfeld zu verbessern.
+Pausen und Reflexion verbinden Elemente des Empirie und des Lean-Denkens, schaffen die Grundlage für Transparenz, Überprüfung und Anpassung an das Produktziel und helfen dem Scrum Team und den Unterstützern, sich selbst und ihr Umfeld zu verbessern.
 
-Eine effektive Einführung von Scrum verringert die Distanz zwischen Stakeholdern, die Probleme oder Chancen aufzeigen, und den Personen, die sich damit befassen, indem Ziele greifbar und sinnvoll bleiben und schnell und häufig Wert geliefert wird. Stakeholder haben oft ein falsches Gefühl der Gewissheit darüber, was und wie etwas zu tun ist. Das Scrum-Team hat oft ein falsches Gefühl der Gewissheit darüber, wer davon betroffen ist. Überprüfen und Anpassen sollte mehr geschätzt werden als das Einhalten von Versprechen oder das Bedienen der falschen Stakeholder. Alle Annahmen können falsch sein.
+Eine effektive Einführung von Scrum verringert die Distanz zwischen Stakeholdern, die Probleme oder Chancen aufzeigen, und den Personen, die sich damit befassen, indem Ziele greifbar und sinnvoll bleiben und schnell und häufig Wert geliefert wird. Stakeholder haben oft ein falsches Gefühl der Gewissheit darüber, was und wie etwas zu tun ist. Das Scrum Team hat oft ein falsches Gefühl der Gewissheit darüber, wer davon betroffen ist. Überprüfen und Anpassen sollte mehr geschätzt werden als das Einhalten von Versprechen oder das Bedienen der falschen Stakeholder. Alle Annahmen können falsch sein.
 
 ### Kadenz {#cadence}
 
-Die Arbeit in Sprints sorgt für einen gleichmäßigen Rhythmus, der dem Scrum-Team hilft, sich auf klare, kurzfristige Ziele zu konzentrieren. Diese Kadenz unterstützt regelmäßige Überprüfungen und Anpassungen, sodass das Scrum-Team aus Feedback lernen und sich entsprechend anpassen kann. Mit der Zeit entsteht so ein nachhaltiges Tempo für die (Produkt-)Lieferung, wodurch die Vorhersagbarkeit verbessert und kontinuierliche Verbesserungen gefördert werden.
+Die Arbeit in Sprints sorgt für einen gleichmäßigen Rhythmus, der dem Scrum Team hilft, sich auf klare, kurzfristige Ziele zu konzentrieren. Diese Kadenz unterstützt regelmäßige Überprüfungen und Anpassungen, sodass das Scrum Team aus Feedback lernen und sich entsprechend anpassen kann. Mit der Zeit entsteht so ein nachhaltiges Tempo für die (Produkt-)Lieferung, wodurch die Vorhersagbarkeit verbessert und kontinuierliche Verbesserungen gefördert werden.
 
 ## Die drei Säulen der empirischen Prozesssteuerung von Scrum {#the-three-pillars-of-scrum’s-empirical-process-control}
 
@@ -164,7 +164,7 @@ Transparenz zu erreichen ist unrealistisch und möglicherweise nicht umsetzbar, 
 
 ### Inspektion {#inspection}
 
-Inspektion ist eine Säule von Scrum. Inspektion bedeutet, die Realität zu betrachten, unter Berücksichtigung der Richtung des Produkts (des Produktziels) und der Effektivität des Scrum-Teams und der Stakeholder. Inspektion ermöglicht Anpassung. Bei der Inspektion geht es darum, die Realität bewusst zu betrachten und sich dabei auf die Dinge zu stützen, die transparent gemacht wurden, einschließlich Beweisen oder Beobachtungen. Um Inspektion und Anpassung zu fördern, sorgt Scrum mit seinen Events für einen regelmäßigen Rhythmus.
+Inspektion ist eine Säule von Scrum. Inspektion bedeutet, die Realität zu betrachten, unter Berücksichtigung der Richtung des Produkts (des Produktziels) und der Effektivität des Scrum Teams und der Stakeholder. Inspektion ermöglicht Anpassung. Bei der Inspektion geht es darum, die Realität bewusst zu betrachten und sich dabei auf die Dinge zu stützen, die transparent gemacht wurden, einschließlich Beweisen oder Beobachtungen. Um Inspektion und Anpassung zu fördern, sorgt Scrum mit seinen Events für einen regelmäßigen Rhythmus.
 
 Die Scrum-Artefakte, die damit verbundenen Verpflichtungen und die Fortschritte bei der Erreichung der vereinbarten Ziele müssen häufig und sorgfältig inspiziert werden, um neue Entwicklungen zu erkennen (71). Die Inspektion der Artefakte, Experimente, Releases, des Marktes oder des Ergebnisfeedbacks kann zu Erkenntnissen oder Nebenwirkungen führen. Nebenwirkungen sind unerwartete oder unbeabsichtigte Ergebnisse oder Folgen.
 
@@ -172,39 +172,39 @@ Eine Inspektion ohne Transparenz ist uninformiert, irreführend und verschwender
 
 ### Anpassung {#adaptation}
 
-Anpassung ist eine Säule von Scrum. Angesichts der Richtung des Produkts wird vom Scrum-Team und den Stakeholdern erwartet, dass sie sich an die Realität anpassen, sobald sich Verbesserungsmöglichkeiten ergeben, wie z. B. Ergebnisse von Experimenten, Erkenntnisse, Risiken oder Chancen. Anpassung wird schwieriger, wenn institutionelle Ineffizienzen bestehen oder wenn die beteiligten Personen nicht bereit, willens oder in der Lage sind, das zu tun, was getan werden muss.
+Anpassung ist eine Säule von Scrum. Angesichts der Richtung des Produkts wird vom Scrum Team und den Stakeholdern erwartet, dass sie sich an die Realität anpassen, sobald sich Verbesserungsmöglichkeiten ergeben, wie z. B. Ergebnisse von Experimenten, Erkenntnisse, Risiken oder Chancen. Anpassung wird schwieriger, wenn institutionelle Ineffizienzen bestehen oder wenn die beteiligten Personen nicht bereit, willens oder in der Lage sind, das zu tun, was getan werden muss.
 
-Anpassung beginnt mit der Akzeptanz der „Realität” auf der Grundlage von Fakten. Anpassung findet in der Regel in den Scrum-Artefakten, den damit verbundenen Verpflichtungen, dem Scrum-Team, den Stakeholdern, den Führungskräften und der Organisation statt. Wenn Aspekte außerhalb der akzeptablen Grenzen oder Rahmenbedingungen liegen oder das resultierende Produkt inakzeptabel ist, müssen so schnell wie möglich Anpassungen vorgenommen werden, um den Kurs zu korrigieren.
+Anpassung beginnt mit der Akzeptanz der „Realität” auf der Grundlage von Fakten. Anpassung findet in der Regel in den Scrum-Artefakten, den damit verbundenen Verpflichtungen, dem Scrum Team, den Stakeholdern, den Führungskräften und der Organisation statt. Wenn Aspekte außerhalb der akzeptablen Grenzen oder Rahmenbedingungen liegen oder das resultierende Produkt inakzeptabel ist, müssen so schnell wie möglich Anpassungen vorgenommen werden, um den Kurs zu korrigieren.
 
 Ohne Anpassung sind Transparenz und Überprüfung bedeutungslos.
 
 ## Die Scrum-Werte {#the-scrum-values}
 
-Die Scrum-Werte – Fokus, Offenheit, Engagement, Mut und Respekt – tragen dazu bei, ein Scrum-Team-Umfeld zu schaffen, das psychologische Sicherheit und positive Zusammenarbeit fördert und mit den Prinzipien übereinstimmt, die in der Neurowissenschaft als förderlich für das Lernen und effektive Teamarbeit identifiziert wurden. Berücksichtigen Sie den Kontext.
+Die Scrum-Werte – Fokus, Offenheit, Engagement, Mut und Respekt – tragen dazu bei, ein Scrum Team-Umfeld zu schaffen, das psychologische Sicherheit und positive Zusammenarbeit fördert und mit den Prinzipien übereinstimmt, die in der Neurowissenschaft als förderlich für das Lernen und effektive Teamarbeit identifiziert wurden. Berücksichtigen Sie den Kontext.
 
-Die Scrum-Werte fördern Transparenz und Vertrauen und stellen sicher, dass Worte und Taten übereinstimmen. Zusammen bilden sie eine starke Grundlage für Zusammenarbeit, Leistung und Kohärenz innerhalb eines Scrum-Teams.
+Die Scrum-Werte fördern Transparenz und Vertrauen und stellen sicher, dass Worte und Taten übereinstimmen. Zusammen bilden sie eine starke Grundlage für Zusammenarbeit, Leistung und Kohärenz innerhalb eines Scrum Teams.
 
-Die erfolgreiche Einführung von Scrum hängt davon ab, dass das Scrum-Team und die Unterstützer (sowie andere Stakeholder) als Fachleute mit gutem Beispiel vorangehen. Die Scrum-Werte können dazu beitragen, das Vertrauen zwischen dem Scrum-Team und den Stakeholdern zu verbessern. Die Scrum-Werte fördern auch Ethik (57), Vokabular, Tonfall, Arbeit, Verhalten und Handlungen, die Vertrauen schaffen. Sie tragen auch dazu bei, die Kluft zwischen Worten und Taten zu verringern oder zu vermeiden.
+Die erfolgreiche Einführung von Scrum hängt davon ab, dass das Scrum Team und die Unterstützer (sowie andere Stakeholder) als Fachleute mit gutem Beispiel vorangehen. Die Scrum-Werte können dazu beitragen, das Vertrauen zwischen dem Scrum Team und den Stakeholdern zu verbessern. Die Scrum-Werte fördern auch Ethik (57), Vokabular, Tonfall, Arbeit, Verhalten und Handlungen, die Vertrauen schaffen. Sie tragen auch dazu bei, die Kluft zwischen Worten und Taten zu verringern oder zu vermeiden.
 
-Das Scrum-Team und die Unterstützer verpflichten sich zu Offenheit in Bezug auf alle Arbeiten und Herausforderungen. Demut fördert Offenheit. Offenheit erfordert Vertrauen, und Vertrauen erfordert Offenheit. Das Scrum-Team und die Unterstützer sollten konstruktives Feedback einholen und weitergeben. Sie arbeiten regelmäßig zusammen und lernen durch intensive Gespräche und qualitatives oder quantitatives Feedback.
+Das Scrum Team und die Unterstützer verpflichten sich zu Offenheit in Bezug auf alle Arbeiten und Herausforderungen. Demut fördert Offenheit. Offenheit erfordert Vertrauen, und Vertrauen erfordert Offenheit. Das Scrum Team und die Unterstützer sollten konstruktives Feedback einholen und weitergeben. Sie arbeiten regelmäßig zusammen und lernen durch intensive Gespräche und qualitatives oder quantitatives Feedback.
 
 Gespräche mit hoher Bandbreite sind Gespräche, die die Kommunikation in einer Weise fördern, die einen möglichst reichhaltigen, schnellen und klaren Informationsaustausch ermöglicht. Dazu gehören in der Regel persönliche Gespräche – entweder von Angesicht zu Angesicht, per Videoanruf, visuelles Management oder Whiteboards (physisch oder digital) –, bei denen die Teilnehmer nicht nur Worte, sondern auch den Tonfall, Mimik, Zeichnungen oder Körpersprache einsetzen können, um sich gegenseitig vollständig zu verstehen.
 
 Da Sprints kurz sind, sollten etwaige Fehler klein und schnell zu beheben sein. Risiken werden durch schnelles und offenes Feedback identifiziert und gemanagt. Der einzige wirkliche Fehler ist vielleicht die Abwesenheit von Lernprozessen.
 
-Das Scrum-Team und die Unterstützer sollten den Mut haben, das Richtige zu tun und sich schwierigen Herausforderungen zu stellen. Sie sollten mutig sein, Unbekanntes zu erforschen, die Richtung zu ändern, Informationen anzufordern und weiterzugeben und höfliche Meinungsverschiedenheiten, z. B. gesunde Konflikte und konstruktive Meinungsverschiedenheiten, zu führen. Das Scrum-Team sollte die Unterstützer und Führungskräfte bei Bedarf um Hilfe bitten.
+Das Scrum Team und die Unterstützer sollten den Mut haben, das Richtige zu tun und sich schwierigen Herausforderungen zu stellen. Sie sollten mutig sein, Unbekanntes zu erforschen, die Richtung zu ändern, Informationen anzufordern und weiterzugeben und höfliche Meinungsverschiedenheiten, z. B. gesunde Konflikte und konstruktive Meinungsverschiedenheiten, zu führen. Das Scrum Team sollte die Unterstützer und Führungskräfte bei Bedarf um Hilfe bitten.
 
-Das Scrum-Team verpflichtet sich, das Sprint-Ziel zu erreichen und sich gegenseitig zu unterstützen. Verpflichtung bedeutet, relevante Arbeit für das Sprint-Ziel zu leisten, um spätestens am Ende des Sprints, vorzugsweise jedoch viel früher, die Definition der erbrachten Leistung zu erfüllen. Verpflichtung bedeutet auch, durch Wertrealisierung die gewünschten Ergebnisse zu erzielen.
+Das Scrum Team verpflichtet sich, das Sprint-Ziel zu erreichen und sich gegenseitig zu unterstützen. Verpflichtung bedeutet, relevante Arbeit für das Sprint-Ziel zu leisten, um spätestens am Ende des Sprints, vorzugsweise jedoch viel früher, die Definition der erbrachten Leistung zu erfüllen. Verpflichtung bedeutet auch, durch Wertrealisierung die gewünschten Ergebnisse zu erzielen.
 
-Ihr primärer Fokus liegt darauf, den bestmöglichen Fortschritt in Richtung des Sprint-Ziels zu erzielen. Ihr sekundärer Fokus liegt darauf, den bestmöglichen Fortschritt in Richtung des Produktziels zu erzielen. Die Unterstützer verpflichten sich, dem Scrum-Team einen psychologisch sicheren Raum und ein Umfeld zu bieten, in dem es Inkremente liefern kann. Im Rahmen ihres Fokus verpflichten sich das Scrum-Team und die Unterstützer, Zeit für kontinuierliches Lernen und Anpassung sowie für den Transfer von Lerninhalten zwischen Scrum-Teams zu schaffen, um die langfristige Effektivität sicherzustellen. Das Scrum-Team und die Stakeholder sollten bewusst Kompromisse eingehen und dabei auch kurzfristige Gewinne mit langfristigen Konsequenzen berücksichtigen.
+Ihr primärer Fokus liegt darauf, den bestmöglichen Fortschritt in Richtung des Sprint-Ziels zu erzielen. Ihr sekundärer Fokus liegt darauf, den bestmöglichen Fortschritt in Richtung des Produktziels zu erzielen. Die Unterstützer verpflichten sich, dem Scrum Team einen psychologisch sicheren Raum und ein Umfeld zu bieten, in dem es Inkremente liefern kann. Im Rahmen ihres Fokus verpflichten sich das Scrum Team und die Unterstützer, Zeit für kontinuierliches Lernen und Anpassung sowie für den Transfer von Lerninhalten zwischen Scrum Teams zu schaffen, um die langfristige Effektivität sicherzustellen. Das Scrum Team und die Stakeholder sollten bewusst Kompromisse eingehen und dabei auch kurzfristige Gewinne mit langfristigen Konsequenzen berücksichtigen.
 
-Das Scrum-Team und die Unterstützer (sowie andere Stakeholder) respektieren einander als qualifizierte Fachleute; sie respektieren die unterschiedlichen Fachkenntnisse und Perspektiven der anderen und gehen konstruktiv mit Meinungsverschiedenheiten um. Respektvolles Verhalten fördert das Vertrauen. Das Scrum-Team und die Unterstützer sollten Ideen oder Ansätze kritisieren, um effektivere Optionen zu finden, nicht die Person(en).
+Das Scrum Team und die Unterstützer (sowie andere Stakeholder) respektieren einander als qualifizierte Fachleute; sie respektieren die unterschiedlichen Fachkenntnisse und Perspektiven der anderen und gehen konstruktiv mit Meinungsverschiedenheiten um. Respektvolles Verhalten fördert das Vertrauen. Das Scrum Team und die Unterstützer sollten Ideen oder Ansätze kritisieren, um effektivere Optionen zu finden, nicht die Person(en).
 
 Respekt schützt davor, dass andere Scrum-Werte als Waffen eingesetzt werden. Respekt kann sich unter anderem durch aufrichtiges Lob, gegenseitige Unterstützung, Bescheidenheit, psychologische Sicherheit, konstruktive Meinungsverschiedenheiten und kognitive Vielfalt äußern.
 
-Die Mitglieder des Scrum-Teams und die Stakeholder können die Scrum-Werte durch die Linse von John Boyds OODA (99, 100, 102) betrachten. OODA (Observe, Orient, Decide, Act) wurde von John Boyd, einem Oberst der US-Luftwaffe, entwickelt, um Piloten dabei zu helfen, in schnell wechselnden Situationen schnelle und kluge Entscheidungen zu treffen, indem sie vier Schritte durchlaufen: Beobachten, Orientieren, Entscheiden und Handeln. Es handelt sich um eine einfache, kontinuierliche, iterative und leistungsstarke, wenn auch oft unbewusste Methode, um mit Unsicherheiten umzugehen – wie beispielsweise Marktveränderungen zu erkennen (Beobachten), Trends und Risiken zu analysieren (Orientieren), zu testende Produktmerkmale auszuwählen (Entscheiden) und diese zu liefern (Handeln). OODA hilft Einzelpersonen, flexibel zu bleiben und gut auf alles zu reagieren, was auf sie zukommt. Scrum kann OODA verbessern.
+Die Mitglieder des Scrum Teams und die Stakeholder können die Scrum-Werte durch die Linse von John Boyds OODA (99, 100, 102) betrachten. OODA (Observe, Orient, Decide, Act) wurde von John Boyd, einem Oberst der US-Luftwaffe, entwickelt, um Piloten dabei zu helfen, in schnell wechselnden Situationen schnelle und kluge Entscheidungen zu treffen, indem sie vier Schritte durchlaufen: Beobachten, Orientieren, Entscheiden und Handeln. Es handelt sich um eine einfache, kontinuierliche, iterative und leistungsstarke, wenn auch oft unbewusste Methode, um mit Unsicherheiten umzugehen – wie beispielsweise Marktveränderungen zu erkennen (Beobachten), Trends und Risiken zu analysieren (Orientieren), zu testende Produktmerkmale auszuwählen (Entscheiden) und diese zu liefern (Handeln). OODA hilft Einzelpersonen, flexibel zu bleiben und gut auf alles zu reagieren, was auf sie zukommt. Scrum kann OODA verbessern.
 
-Einzelne Mitglieder des Scrum-Teams können die Scrum-Werte durch die Linse von John Boyds OODA betrachten und Scrum nutzen, um neue Lösungen zu entwickeln. Im Scrum-Kontext gelten die Scrum-Werte für alle OODA-Phasen und helfen insbesondere wie folgt:
+Einzelne Mitglieder des Scrum Teams können die Scrum-Werte durch die Linse von John Boyds OODA betrachten und Scrum nutzen, um neue Lösungen zu entwickeln. Im Scrum-Kontext gelten die Scrum-Werte für alle OODA-Phasen und helfen insbesondere wie folgt:
 
 - Beobachten – Offenheit und Respekt können das Sammeln aller relevanten Informationen und unterschiedlicher Perspektiven fördern.
 - Orientieren – Mut ist erforderlich, um die Realität zu interpretieren, Unsicherheiten zu bewältigen und sich auf Anpassungen oder Kursänderungen einzulassen, möglicherweise unter Einlegen einer reflektierenden Pause, um Annahmen zu hinterfragen und neue Erkenntnisse zu gewinnen.
@@ -223,7 +223,7 @@ Um „die Kluft zu überwinden”, ist eine Strategieänderung erforderlich: Ans
 
 Produkt Owner müssen den Umgang mit Kompromissen zwischen dem „Hier und Jetzt” und der erwarteten Zukunft (dem „Dort und Dann”) (148) durch Mut, Bescheidenheit, Beratung, Zusammenarbeit, gesunde Konflikte usw. meistern.
 
-Angenommen, die beteiligten Personen sind reine Kurzzeitdenker. In diesem Fall werden sie wahrscheinlich langfristige Nebenwirkungen wie technische Schulden, niedrige Moral im Scrum-Team, Hektik, Output-Fokus usw. erleben. Aus diesem Grund müssten mildernde Faktoren eingeführt werden, um die langfristige Entwicklung zu unterstützen.
+Angenommen, die beteiligten Personen sind reine Kurzzeitdenker. In diesem Fall werden sie wahrscheinlich langfristige Nebenwirkungen wie technische Schulden, niedrige Moral im Scrum Team, Hektik, Output-Fokus usw. erleben. Aus diesem Grund müssten mildernde Faktoren eingeführt werden, um die langfristige Entwicklung zu unterstützen.
 
 Technische Schulden sind die zusätzliche Arbeit, die sich – bewusst oder unbewusst – ansammelt, wenn Sie bei der Umsetzung oder dem Design Abkürzungen nehmen, um etwas schneller zu liefern. Mit der Zeit verlangsamen sie Sie, genau wie echte Schulden – mit Zinsen –, weil sie zukünftige Änderungen schwieriger und riskanter machen. Fachleute sind bestrebt, technische Schulden und Schlampigkeit so weit wie möglich zu minimieren. Wenn sie sich entscheiden, Schulden zu machen, sollte dies transparent sein, und wenn möglich, sollte ein Notfallplan vorhanden sein.
 
@@ -240,15 +240,15 @@ Scrum bevorzugt ein gesundes Gleichgewicht zwischen kurzfristigen und langfristi
 
 Systemisches Denken (55) erkennt die Vernetzung von Elementen innerhalb organisatorischer und sozialer Kontexte an und berücksichtigt, dass Maßnahmen in einem Bereich Auswirkungen haben, die nicht immer vorhersehbar oder linear sind. Theoriegestützte Experimente, Feedback-Schleifen und nachfolgende Datenanalysen helfen dabei, wertvolle und umsetzbare Erkenntnisse zu gewinnen. Systemisches Denken liefert wertvolle Werkzeuge und Ideen und erleichtert die Gewinnung von Erkenntnissen.
 
-Damit eine Organisation anpassungsfähig wird (80), müssen lokale Suboptimierungen vermieden werden, wie z. B. die Senkung der Stückkosten bei gleichzeitiger Erhöhung der langfristigen Kosten, die Aushöhlung von Qualitätszielen, die zum Verlust des Kundenvertrauens führen, oder die Verbesserung eines Scrum-Teams, eines Workflows oder eines Prozesses, der nicht existieren sollte. Bei komplexen Aufgaben (30-35) ist es nicht immer möglich, Ursache und Wirkung miteinander zu verknüpfen, außer im Nachhinein. Dennoch ist es hilfreich, mögliche und tatsächliche vorgelagerte, quer verlaufende und nachgelagerte Auswirkungen von Interventionen zu berücksichtigen.
+Damit eine Organisation anpassungsfähig wird (80), müssen lokale Suboptimierungen vermieden werden, wie z. B. die Senkung der Stückkosten bei gleichzeitiger Erhöhung der langfristigen Kosten, die Aushöhlung von Qualitätszielen, die zum Verlust des Kundenvertrauens führen, oder die Verbesserung eines Scrum Teams, eines Workflows oder eines Prozesses, der nicht existieren sollte. Bei komplexen Aufgaben (30-35) ist es nicht immer möglich, Ursache und Wirkung miteinander zu verknüpfen, außer im Nachhinein. Dennoch ist es hilfreich, mögliche und tatsächliche vorgelagerte, quer verlaufende und nachgelagerte Auswirkungen von Interventionen zu berücksichtigen.
 
 ### Entdeckung (Discovery) {#discovery}
 
-Die Entdeckung (50-51) beginnt oft damit, die Erwartungen, Bedürfnisse und Wünsche der Menschen durch Beobachtung, Analyse, Gespräche und Synthese zu verstehen, um zu einem gewünschten Ergebnis zu gelangen. Sobald ein Scrum-Team Erkenntnisse gesammelt hat, formuliert es das Problem oder die Chance und ordnet sie nach ihrem potenziellen Wert. Das Scrum-Team sammelt mögliche Lösungen, ohne sie vorschnell zu beurteilen. Wenn der potenzielle Wert hoch ist, aber keine Belege dafür vorliegen, dass dieser Wert auch realisiert werden kann, sollte das Scrum-Team Recherchen durchführen, Annahmen überprüfen oder einfache Prototypen erstellen, die mit echten Kunden, Entscheidungsträgern oder Anwendern getestet werden können. Die Entdeckung ist nie abgeschlossen; regelmäßige Interviews oder Beobachtungen von Kunden, Entscheidungsträgern oder Anwendern sind daher empfehlenswert.
+Die Entdeckung (50-51) beginnt oft damit, die Erwartungen, Bedürfnisse und Wünsche der Menschen durch Beobachtung, Analyse, Gespräche und Synthese zu verstehen, um zu einem gewünschten Ergebnis zu gelangen. Sobald ein Scrum Team Erkenntnisse gesammelt hat, formuliert es das Problem oder die Chance und ordnet sie nach ihrem potenziellen Wert. Das Scrum Team sammelt mögliche Lösungen, ohne sie vorschnell zu beurteilen. Wenn der potenzielle Wert hoch ist, aber keine Belege dafür vorliegen, dass dieser Wert auch realisiert werden kann, sollte das Scrum Team Recherchen durchführen, Annahmen überprüfen oder einfache Prototypen erstellen, die mit echten Kunden, Entscheidungsträgern oder Anwendern getestet werden können. Die Entdeckung ist nie abgeschlossen; regelmäßige Interviews oder Beobachtungen von Kunden, Entscheidungsträgern oder Anwendern sind daher empfehlenswert.
 
-Bei der Entdeckung geht es darum, durch Priorisierung, Umsetzung, Vermeidung oder ständige Verbesserung von Ideen, die auf Benutzerbeobachtungen, Feedback oder anderen Erkenntnissen basieren, zu einem gewünschten Ergebnis zu gelangen. Die Entdeckung betont Zusammenarbeit, Kreativität und die Bereitschaft, Fehler zu machen und es erneut zu versuchen. Die Entdeckung fasst die Arbeit als Probleme oder Chancen zusammen und hilft dem Scrum-Team, Lösungsoptionen zu entwickeln, zu priorisieren und zu testen, die die Wünsche der Menschen, die technischen Möglichkeiten und die geschäftliche Sinnhaftigkeit in Einklang bringen – und das alles mit Spaß.
+Bei der Entdeckung geht es darum, durch Priorisierung, Umsetzung, Vermeidung oder ständige Verbesserung von Ideen, die auf Benutzerbeobachtungen, Feedback oder anderen Erkenntnissen basieren, zu einem gewünschten Ergebnis zu gelangen. Die Entdeckung betont Zusammenarbeit, Kreativität und die Bereitschaft, Fehler zu machen und es erneut zu versuchen. Die Entdeckung fasst die Arbeit als Probleme oder Chancen zusammen und hilft dem Scrum Team, Lösungsoptionen zu entwickeln, zu priorisieren und zu testen, die die Wünsche der Menschen, die technischen Möglichkeiten und die geschäftliche Sinnhaftigkeit in Einklang bringen – und das alles mit Spaß.
 
-Wenn Entdeckung erforderlich ist, sollte sie (soweit möglich) in einer Weise einbezogen werden, die mit Scrum vereinbar ist. Beispielsweise wird die Entdeckungsarbeit im Product Backlog und Sprint Backlog transparent gemacht, die Mitglieder des Scrum-Teams üben Entdeckung und andere Fähigkeiten, Erkenntnisse werden während des Sprints und bei den Scrum-Events diskutiert, und unabhängig davon, wie viel Entdeckung geleistet wurde, wird in jedem Sprint mindestens ein Inkrement produziert (und idealerweise veröffentlicht). Es gilt, ein Gleichgewicht zu finden: Entdeckungen können helfen, Fehlkonstruktionen zu vermeiden, aber sie können auch übertrieben werden, und letztendlich ist das Ergebnisfeedback am wichtigsten.
+Wenn Entdeckung erforderlich ist, sollte sie (soweit möglich) in einer Weise einbezogen werden, die mit Scrum vereinbar ist. Beispielsweise wird die Entdeckungsarbeit im Product Backlog und Sprint Backlog transparent gemacht, die Mitglieder des Scrum Teams üben Entdeckung und andere Fähigkeiten, Erkenntnisse werden während des Sprints und bei den Scrum-Events diskutiert, und unabhängig davon, wie viel Entdeckung geleistet wurde, wird in jedem Sprint mindestens ein Inkrement produziert (und idealerweise veröffentlicht). Es gilt, ein Gleichgewicht zu finden: Entdeckungen können helfen, Fehlkonstruktionen zu vermeiden, aber sie können auch übertrieben werden, und letztendlich ist das Ergebnisfeedback am wichtigsten.
 
 ### Führung {#leadership}
 
@@ -256,17 +256,17 @@ Führung ist die Fähigkeit, eine Gruppe von Menschen zu beeinflussen, zu leiten
 
 Führung ist ein dynamischer sozialer Prozess, der Verantwortung, den Aufbau von Beziehungen und Empowerment umfasst. Erfolgreiche Führung führt zur gemeinsamen Festlegung einer Richtung, zur effektiven Abstimmung der erforderlichen Ressourcen und Personen und zu gegenseitigem Engagement der Gruppenmitglieder.
 
-Scrum strebt eine bestimmte Art von Führung an, nämlich Führung für Resilienz, eine Reihe von Eigenschaften und keine Managementposition. Daher muss Führung unter anderem die Schaffung eines Umfelds für selbst-gemanagte Scrum-Teams, Klarheit, Vertrauen, Transparenz, Emergenz (71) in einer Richtung, Erfüllung bei der Arbeit, die Akzeptanz von Unsicherheit (72) und Fehlern, das Sammeln von Beweisen für bessere Entscheidungen, proaktives Risikomanagement und die Beseitigung von organisatorischen Ineffizienzen umfassen.
+Scrum strebt eine bestimmte Art von Führung an, nämlich Führung für Resilienz, eine Reihe von Eigenschaften und keine Managementposition. Daher muss Führung unter anderem die Schaffung eines Umfelds für selbst-gemanagte Scrum Teams, Klarheit, Vertrauen, Transparenz, Emergenz (71) in einer Richtung, Erfüllung bei der Arbeit, die Akzeptanz von Unsicherheit (72) und Fehlern, das Sammeln von Beweisen für bessere Entscheidungen, proaktives Risikomanagement und die Beseitigung von organisatorischen Ineffizienzen umfassen.
 
 Führung findet aus allen Blickwinkeln statt, sollte auf allen Ebenen vorhanden sein und zur richtigen Zeit Reflexion fördern. Führung sollte konsequent auf Werte ausgerichtet sein, aber dennoch mitfühlend und ethisch handeln. Führung erfordert beharrliches Handeln, um Arbeitsabläufe, Prozesse, Systeme und das Arbeitsumfeld zu verändern; dazu gehören (unter anderem) Personalwesen, Finanzen und Lieferantenmanagement. Ein Führungskraft ist jemand, der Führungsqualitäten zeigt.
 
-Produkt Owner und Scrum Master schaffen ein Gleichgewicht zwischen Führung, Autorität und subtiler Kontrolle, indem sie klare Absichten vermitteln, Initiative fördern und Verantwortlichkeiten stärken. Sie leiten eher, als dass sie mikromanagen, und stellen sicher, dass das Scrum-Team die Vision und die Ziele versteht, über die nötige Autonomie zur Umsetzung verfügt und für die Ergebnisse verantwortlich bleibt. Wenn ein Eingreifen erforderlich ist, greifen sie entschlossen ein, ohne dass das Scrum-Team die Verantwortung für seine Aufgaben verliert. Produktentwickler zeigen Führungsqualitäten durch ihre selbst-gemanagte Teamorientierung, ihre Professionalität und ihre Zielorientierung; Selbst-Management geht mit Verantwortung einher. Unterstützer zeigen Führungsqualitäten, indem sie kurz- und langfristige Hindernisse beseitigen, die Kohärenz der Managementprozesse mit Scrum verbessern und bei Bedarf dringende Veränderungen in eine positive Richtung unterstützen.
+Produkt Owner und Scrum Master schaffen ein Gleichgewicht zwischen Führung, Autorität und subtiler Kontrolle, indem sie klare Absichten vermitteln, Initiative fördern und Verantwortlichkeiten stärken. Sie leiten eher, als dass sie mikromanagen, und stellen sicher, dass das Scrum Team die Vision und die Ziele versteht, über die nötige Autonomie zur Umsetzung verfügt und für die Ergebnisse verantwortlich bleibt. Wenn ein Eingreifen erforderlich ist, greifen sie entschlossen ein, ohne dass das Scrum Team die Verantwortung für seine Aufgaben verliert. Product Developer zeigen Führungsqualitäten durch ihre selbst-gemanagte Teamorientierung, ihre Professionalität und ihre Zielorientierung; Selbst-Management geht mit Verantwortung einher. Unterstützer zeigen Führungsqualitäten, indem sie kurz- und langfristige Hindernisse beseitigen, die Kohärenz der Managementprozesse mit Scrum verbessern und bei Bedarf dringende Veränderungen in eine positive Richtung unterstützen.
 
 ### First Principles Thinking {#first-principles-thinking}
 
 First Principles Thinking ist eine Methode zur Problemlösung, bei der Herausforderungen in ihre grundlegendsten Wahrheiten zerlegt und Lösungen von Grund auf gefunden werden. Anstatt sich auf Analogien oder etablierte Konventionen zu verlassen, fragt dieser Ansatz: „Was wissen wir mit Sicherheit?“ und rekonstruiert das Verständnis und die Lösungen aus diesen grundlegenden Elementen. Beispiele hierfür sind unter anderem:
 
-- Das Scrum-Team dazu ermutigen, sich auf die Kernfaktoren für Effektivität, Anpassungsfähigkeit (80) und Pünktlichkeit zu konzentrieren – wie Autonomie, Transparenz und Anpassungsfähigkeit –, anstatt blind Prozesse zu befolgen oder das zu kopieren, was andere getan haben.
+- Das Scrum Team dazu ermutigen, sich auf die Kernfaktoren für Effektivität, Anpassungsfähigkeit (80) und Pünktlichkeit zu konzentrieren – wie Autonomie, Transparenz und Anpassungsfähigkeit –, anstatt blind Prozesse zu befolgen oder das zu kopieren, was andere getan haben.
 - Jede Annahme hinterfragen und Lösungen auf der Grundlage von Fakten und wesentlichen Prinzipien rekonstruieren, was zu Durchbrüchen führen kann.
 - Förderung von originellem Denken, kontinuierlicher Verbesserung und dem Mut, den Status quo in Frage zu stellen – um Kreativität freizusetzen und transformative Ergebnisse zu ermöglichen.
 
@@ -282,41 +282,41 @@ Beginnen Sie mit disziplinierten, emergenten Veränderungen in eine bestimmte Ri
 
 ## Die Scrum-Rollen im Erweiterungspaket {#the-scrum-roles-in-the-expansion-pack}
 
-Die vier Scrum-Rollen sind Produkt Owner, Produktentwickler, Scrum Master und Stakeholder. Sie geben, belohnen und verdienen Vertrauen und ermöglichen eine kohärente Führung. Nur die drei Verantwortlichkeiten Produkt Owner, Produktentwickler und Scrum Master gehören zum Scrum-Team.
+Die vier Scrum-Rollen sind Produkt Owner, Product Developer, Scrum Master und Stakeholder. Sie geben, belohnen und verdienen Vertrauen und ermöglichen eine kohärente Führung. Nur die drei Verantwortlichkeiten Produkt Owner, Product Developer und Scrum Master gehören zum Scrum Team.
 
 Eine Person kann mehr als eine Scrum-Rolle innehaben. Wenn man mehr als eine Rolle übernimmt, muss man darauf achten, dass man sich nicht überschreitet. Die Scrum-Rollen sind so konzipiert, dass sie gegenseitige Kontrollen und Ausgewogenheit gewährleisten.
 
-Ein Scrum-Team ist ein Team, das Scrum praktiziert, drei Scrum-Verantwortlichkeiten wahrnimmt, nämlich Scrum Master, Produkt Owner und Produktentwickler, sich mit Problemen oder Chancen von Stakeholdern (einschließlich, aber nicht beschränkt auf Kunden oder Nutzer) befasst und aus der Perspektive des Scrum-Teams und der Stakeholder nützliche, nutzbare und potenziell wertvolle Inkremente für das Produktziel liefert. Für komplexe (30-35) Arbeiten sollte ein Scrum-Team klein, kognitiv vielfältig und selbst-gemanagt sein, wobei die menschlichen Mitglieder des Scrum-Teams, oft unterstützt durch Technologie, sich um die Arbeit der anderen kümmern und lernen, die Arbeit der anderen zu erledigen.
+Ein Scrum Team ist ein Team, das Scrum praktiziert, drei Scrum-Verantwortlichkeiten wahrnimmt, nämlich Scrum Master, Produkt Owner und Product Developer, sich mit Problemen oder Chancen von Stakeholdern (einschließlich, aber nicht beschränkt auf Kunden oder Nutzer) befasst und aus der Perspektive des Scrum Teams und der Stakeholder nützliche, nutzbare und potenziell wertvolle Inkremente für das Produktziel liefert. Für komplexe (30-35) Arbeiten sollte ein Scrum Team klein, kognitiv vielfältig und selbst-gemanagt sein, wobei die menschlichen Mitglieder des Scrum Teams, oft unterstützt durch Technologie, sich um die Arbeit der anderen kümmern und lernen, die Arbeit der anderen zu erledigen.
 
-Das Scrum-Team sollte funktionsübergreifend sein, d. h. es ist multidisziplinär und umfasst technische und betriebswirtschaftliche Kompetenzen. Innerhalb des Scrum-Teams gibt es keine explizite Hierarchie. Das Scrum-Team sollte über alle erforderlichen Kompetenzen und Unterstützung verfügen, um
+Das Scrum Team sollte funktionsübergreifend sein, d. h. es ist multidisziplinär und umfasst technische und betriebswirtschaftliche Kompetenzen. Innerhalb des Scrum Teams gibt es keine explizite Hierarchie. Das Scrum Team sollte über alle erforderlichen Kompetenzen und Unterstützung verfügen, um
 
 - bei Bedarf Entdeckungen zu machen (einschließlich Recherche und Design),
 - zu liefern (einschließlich Engineering, wenn erforderlich) und
 - die Wertrealisierung (sowie zusätzlich die Verwendbarkeit, Attraktivität und Realisierbarkeit innerhalb ethischer (57) Grenzen) zu validieren.
 
-Das Scrum-Team kümmert sich mit Unterstützung der Supporter gemeinsam um den Problem- oder Chancenbereich, die Produktentdeckung, die Lieferung, die Verifizierung und die integrierte Qualität, die Markteinführung und die Wertvalidierung im Hinblick auf das Produktziel. Das Scrum-Team strebt nach Nettoverbesserungen; da es selbst-gemanagt ist (49), entscheidet es selbst, wer was, wie, wann und wo tut.
+Das Scrum Team kümmert sich mit Unterstützung der Supporter gemeinsam um den Problem- oder Chancenbereich, die Produktentdeckung, die Lieferung, die Verifizierung und die integrierte Qualität, die Markteinführung und die Wertvalidierung im Hinblick auf das Produktziel. Das Scrum Team strebt nach Nettoverbesserungen; da es selbst-gemanagt ist (49), entscheidet es selbst, wer was, wie, wann und wo tut.
 
 Die Wertvalidierung ist die Bestätigung (oder Widerlegung) innerhalb der gegebenen Grenzen, dass die erwarteten Ergebnisse erzielt wurden.
 
-Das Scrum-Team liefert in jedem Sprint ein oder mehrere Inkremente, verwaltet sich kontinuierlich selbst (49), um Probleme zu finden und zu beheben, synchronisiert sich kontinuierlich und veröffentlicht häufig. Das Scrum-Team ist klein genug, um flexibel zu bleiben, und groß genug, um innerhalb eines Sprints bedeutende Arbeit zu leisten. Oft kommunizieren kleinere Scrum-Teams besser und sind produktiver.
+Das Scrum Team liefert in jedem Sprint ein oder mehrere Inkremente, verwaltet sich kontinuierlich selbst (49), um Probleme zu finden und zu beheben, synchronisiert sich kontinuierlich und veröffentlicht häufig. Das Scrum Team ist klein genug, um flexibel zu bleiben, und groß genug, um innerhalb eines Sprints bedeutende Arbeit zu leisten. Oft kommunizieren kleinere Scrum Teams besser und sind produktiver.
 
-Scrum basiert auf selbst-gemanagten Scrum-Teams (49) innerhalb einer definierten Organisations- oder Produktstruktur. Es besteht Autonomie, die jedoch durch Scrum-Ereignisse, Verantwortlichkeiten, Artefakte, Verpflichtungen, Säulen, Werte und organisatorische Anforderungen begrenzt ist.
+Scrum basiert auf selbst-gemanagten Scrum Teams (49) innerhalb einer definierten Organisations- oder Produktstruktur. Es besteht Autonomie, die jedoch durch Scrum-Ereignisse, Verantwortlichkeiten, Artefakte, Verpflichtungen, Säulen, Werte und organisatorische Anforderungen begrenzt ist.
 
 Scrum bindet Gruppen von Menschen ein, die gemeinsam über alle Fähigkeiten und Fachkenntnisse verfügen oder diese erwerben, um die Arbeit zu erledigen und diese Fähigkeiten bei Bedarf zu teilen. Bewusste Interaktionen, die von Führungskräften unterstützt werden, sind erforderlich, um die Chancen auf erfolgreiche Ergebnisse zu verbessern.
 
 Der Fokus sollte darauf liegen, das Produktziel auf die effektivste Weise und mit dem richtigen Aufwand zu erreichen und gleichzeitig wertvolle Ergebnisse zu liefern.
 
-Scrum fördert die Zusammenarbeit im Team, indem es kontinuierliche Interaktion und gemeinsame Verantwortung fördert, anstatt sequenzielles, isoliertes Arbeiten. Dieser Ansatz ermöglicht es dem Scrum-Team und den Stakeholdern, Unsicherheiten zu akzeptieren (72) und schnellere Anpassungen auf der Grundlage kontinuierlichen Lernens und Feedbacks vorzunehmen. Die Überschneidung von Entdeckung, Entwicklung und Wertvalidierung gewährleistet einen anpassungsfähigeren (80) und wertorientierten Ansatz für die Produktentwicklung.
+Scrum fördert die Zusammenarbeit im Team, indem es kontinuierliche Interaktion und gemeinsame Verantwortung fördert, anstatt sequenzielles, isoliertes Arbeiten. Dieser Ansatz ermöglicht es dem Scrum Team und den Stakeholdern, Unsicherheiten zu akzeptieren (72) und schnellere Anpassungen auf der Grundlage kontinuierlichen Lernens und Feedbacks vorzunehmen. Die Überschneidung von Entdeckung, Entwicklung und Wertvalidierung gewährleistet einen anpassungsfähigeren (80) und wertorientierten Ansatz für die Produktentwicklung.
 
-Überschneidende Arbeiten fördern die gemeinsame Verantwortung innerhalb des Scrum-Teams und stärken so das Engagement und die Einsatzbereitschaft. Das Scrum-Team konzentriert sich auf die Bewältigung von Herausforderungen und Chancen, fördert proaktives Verhalten, fördert die Entwicklung vielfältiger Fähigkeiten und schärft das Bewusstsein aller Beteiligten für die Marktdynamik.
+Überschneidende Arbeiten fördern die gemeinsame Verantwortung innerhalb des Scrum Teams und stärken so das Engagement und die Einsatzbereitschaft. Das Scrum Team konzentriert sich auf die Bewältigung von Herausforderungen und Chancen, fördert proaktives Verhalten, fördert die Entwicklung vielfältiger Fähigkeiten und schärft das Bewusstsein aller Beteiligten für die Marktdynamik.
 
-Das Scrum-Team kümmert sich um alle produktbezogenen Aktivitäten, von der Zusammenarbeit mit den Stakeholdern bis zur Wertvalidierung, einschließlich Verifizierung, Wartung, Betrieb, Experimenten, Forschung und Entwicklung sowie allem, was sonst noch erforderlich sein könnte. Das Scrum-Team sorgt für Qualität. Unterstützer sorgen dafür, dass die Organisation das Klima und das Arbeitsumfeld gestaltet und das Scrum-Team zum Selbst-Management befähigt (49). Die Arbeit in Sprints in einem nachhaltigen Tempo verbessert die Fokussierung und Konsistenz.
+Das Scrum Team kümmert sich um alle produktbezogenen Aktivitäten, von der Zusammenarbeit mit den Stakeholdern bis zur Wertvalidierung, einschließlich Verifizierung, Wartung, Betrieb, Experimenten, Forschung und Entwicklung sowie allem, was sonst noch erforderlich sein könnte. Das Scrum Team sorgt für Qualität. Unterstützer sorgen dafür, dass die Organisation das Klima und das Arbeitsumfeld gestaltet und das Scrum Team zum Selbst-Management befähigt (49). Die Arbeit in Sprints in einem nachhaltigen Tempo verbessert die Fokussierung und Konsistenz.
 
-Das Scrum-Team und die Stakeholder wissen nicht, was sie lernen werden. Einige Erkenntnisse sorgen für mehr Sicherheit, andere schaffen mehr Unsicherheit (72). Einige Dinge könnten auftauchen, wieder verschwinden, wegfallen oder an Priorität verlieren.
+Das Scrum Team und die Stakeholder wissen nicht, was sie lernen werden. Einige Erkenntnisse sorgen für mehr Sicherheit, andere schaffen mehr Unsicherheit (72). Einige Dinge könnten auftauchen, wieder verschwinden, wegfallen oder an Priorität verlieren.
 
-Ein Scrum-Team verfügt über abgestimmte Autonomie. Abgestimmte Autonomie bedeutet, dass das Scrum-Team die Freiheit hat, selbst zu entscheiden, wie Probleme gelöst werden, während es sich auf gemeinsame Ziele und Ergebnisse konzentriert, was sowohl Innovation als auch organisatorische Kohärenz ermöglicht. Die Förderung eines kognitiv vielfältigen Scrum-Teams ist unerlässlich. Cross-Pollination ist wahrscheinlicher, wenn die Mitglieder des Scrum-Teams zusammenarbeiten, sich gegenseitig vertrauen und selbstreflektiert sind.
+Ein Scrum Team verfügt über abgestimmte Autonomie. Abgestimmte Autonomie bedeutet, dass das Scrum Team die Freiheit hat, selbst zu entscheiden, wie Probleme gelöst werden, während es sich auf gemeinsame Ziele und Ergebnisse konzentriert, was sowohl Innovation als auch organisatorische Kohärenz ermöglicht. Die Förderung eines kognitiv vielfältigen Scrum Teams ist unerlässlich. Cross-Pollination ist wahrscheinlicher, wenn die Mitglieder des Scrum Teams zusammenarbeiten, sich gegenseitig vertrauen und selbstreflektiert sind.
 
-Für erfolgreiche Ergebnisse sollten das Scrum-Team und die Unterstützer die Bereitschaft entwickeln, veraltete Prinzipien zu verlernen. Überprüfung und Anpassung erfordern ein Klima, in dem Fehler antizipiert und toleriert werden. Es ist wichtig, Kritik auf Ideen zu konzentrieren und nicht auf Einzelpersonen. Alle Mitglieder des Scrum-Teams „spielen auf dem gleichen Feld” mit sich überschneidenden Aufgaben und sind alle für den Erfolg verantwortlich.
+Für erfolgreiche Ergebnisse sollten das Scrum Team und die Unterstützer die Bereitschaft entwickeln, veraltete Prinzipien zu verlernen. Überprüfung und Anpassung erfordern ein Klima, in dem Fehler antizipiert und toleriert werden. Es ist wichtig, Kritik auf Ideen zu konzentrieren und nicht auf Einzelpersonen. Alle Mitglieder des Scrum Teams „spielen auf dem gleichen Feld” mit sich überschneidenden Aufgaben und sind alle für den Erfolg verantwortlich.
 
 ### Stakeholder {#stakeholder}
 
@@ -326,9 +326,9 @@ Beispiele für Stakeholder sind (unter anderem) Kunden, Entscheidungsträger, Nu
 
 Ein Kunde ist jeder Stakeholder, der durch den Kauf und/oder die Auswahl des Produkts einen Wert erhält. Zu den Kunden können Käufer (diejenigen, die für das Produkt bezahlen oder es erwerben), Entscheidungsträger (diejenigen, die seine Einführung genehmigen oder autorisieren) und Endnutzer (diejenigen, die direkt mit dem Produkt interagieren) gehören. Manchmal ist der Kunde nicht mit dem Endkunden identisch, z. B. in B2B2C (79) oder B2B2B (78).
 
-Für eine erfolgreiche Einführung von Scrum ist es entscheidend, dass regelmäßige, gezielte Interaktionen zwischen den Stakeholdern (einschließlich, aber nicht beschränkt auf Kunden und Nutzer) und dem Scrum-Team stattfinden.
+Für eine erfolgreiche Einführung von Scrum ist es entscheidend, dass regelmäßige, gezielte Interaktionen zwischen den Stakeholdern (einschließlich, aber nicht beschränkt auf Kunden und Nutzer) und dem Scrum Team stattfinden.
 
-Ein Nutzer ist ein Stakeholder, der direkt mit dem Produkt interagiert, um bestimmte Ziele zu erreichen oder Probleme zu lösen. Nutzer erleben das Produkt aus erster Hand, unabhängig davon, ob es sich um eine Dienstleistung, eine Plattform oder eine Erfahrung handelt, und ihr Feedback und ihre Zufriedenheit sind entscheidend für die kontinuierliche Verbesserung des Produkts. Nutzer haben möglicherweise keinen Einfluss auf Kaufentscheidungen, aber ihre Akzeptanz und ihr Engagement sind für den anhaltenden Erfolg des Produkts von entscheidender Bedeutung. Manchmal ist der Nutzer nicht mit dem Endnutzer identisch, z. B. in B2B2C oder B2B2B. Für eine erfolgreiche Einführung von Scrum ist es entscheidend, dass regelmäßige, gezielte Interaktionen zwischen den Nutzern (und möglicherweise Endnutzern) und dem Scrum-Team stattfinden.
+Ein Nutzer ist ein Stakeholder, der direkt mit dem Produkt interagiert, um bestimmte Ziele zu erreichen oder Probleme zu lösen. Nutzer erleben das Produkt aus erster Hand, unabhängig davon, ob es sich um eine Dienstleistung, eine Plattform oder eine Erfahrung handelt, und ihr Feedback und ihre Zufriedenheit sind entscheidend für die kontinuierliche Verbesserung des Produkts. Nutzer haben möglicherweise keinen Einfluss auf Kaufentscheidungen, aber ihre Akzeptanz und ihr Engagement sind für den anhaltenden Erfolg des Produkts von entscheidender Bedeutung. Manchmal ist der Nutzer nicht mit dem Endnutzer identisch, z. B. in B2B2C oder B2B2B. Für eine erfolgreiche Einführung von Scrum ist es entscheidend, dass regelmäßige, gezielte Interaktionen zwischen den Nutzern (und möglicherweise Endnutzern) und dem Scrum Team stattfinden.
 
 Ein Entscheidungsträger (von Jeff Patton als „Chooser” bezeichnet) (82) ist ein Stakeholder mit der Befugnis, die Einführung oder den Kauf des Produkts zu genehmigen, auszuwählen oder zu autorisieren. Der Entscheidungsträger ist für die Bewertung der Optionen und die endgültige Entscheidung verantwortlich, wobei er häufig die Bedürfnisse sowohl der Nutzer als auch des gesamten Unternehmens berücksichtigt. Entscheidungsträger nutzen das Produkt möglicherweise selbst oder auch nicht, aber ihre Entscheidungen haben direkten Einfluss darauf, welche Produkte eingeführt werden und wie der Wert für andere Stakeholder realisiert wird. Für eine erfolgreiche Einführung von Scrum ist es oft besser, mit unvollständigen Informationen zu arbeiten und Feedback zu den ersten Ergebnissen einzuholen.
 
@@ -336,30 +336,30 @@ Gesetzgeber (sowie, für die Zwecke dieses Dokuments, externe oder interne polit
 
 Finanzielle Sponsoren stellen Finanzmittel und Ressourcen für die Produktentwicklung, -einführung und -verbesserung bereit. Sie bewerten die Rentabilität, den Wert und die Machbarkeit des Produkts und investieren auf der Grundlage seines Potenzials, kontinuierlich Wert für die Stakeholder zu schaffen. Finanzielle Sponsoren beeinflussen die Produktvision, -strategie und -ziele, um die Ausrichtung auf die Kapitalrendite und die langfristige Nachhaltigkeit sicherzustellen. Für eine erfolgreiche Einführung von Scrum ist es entscheidend, flexibel zu sein und die Finanzierung anzupassen, wenn neue Informationen bekannt werden.
 
-Fachexperten bringen fundiertes Wissen oder einzigartige Fähigkeiten ein, die für die Erstellung, Weiterentwicklung und Wartung des Produkts unerlässlich sind. Unabhängig davon, ob sie sich auf Technologie, Design, Compliance oder einen bestimmten Bereich konzentrieren, unterstützen Fachexperten die Benutzerfreundlichkeit, Machbarkeit, Professionalität und Erweiterbarkeit des Produkts, ohne die selbst-gemanagten Scrum-Teams zu behindern (49). Sie können dazu beitragen, Zufriedenheitslücken zu schließen und die Fähigkeit des Produkts zu verbessern, sich anzupassen und neue Entwicklungen zu erkennen, darzustellen oder zu messen (71). Für eine erfolgreiche Einführung von Scrum ist es entscheidend, einen regelmäßigen Wissenstransfer von Fachexperten zum Scrum-Team und innerhalb des Teams zu fördern.
+Fachexperten bringen fundiertes Wissen oder einzigartige Fähigkeiten ein, die für die Erstellung, Weiterentwicklung und Wartung des Produkts unerlässlich sind. Unabhängig davon, ob sie sich auf Technologie, Design, Compliance oder einen bestimmten Bereich konzentrieren, unterstützen Fachexperten die Benutzerfreundlichkeit, Machbarkeit, Professionalität und Erweiterbarkeit des Produkts, ohne die selbst-gemanagten Scrum Teams zu behindern (49). Sie können dazu beitragen, Zufriedenheitslücken zu schließen und die Fähigkeit des Produkts zu verbessern, sich anzupassen und neue Entwicklungen zu erkennen, darzustellen oder zu messen (71). Für eine erfolgreiche Einführung von Scrum ist es entscheidend, einen regelmäßigen Wissenstransfer von Fachexperten zum Scrum Team und innerhalb des Teams zu fördern.
 
 Der Begriff „Zufriedenheitslücke” bezeichnet die Differenz zwischen dem, was Stakeholder derzeit erleben, und dem, was sie sich wünschen würden. Mit anderen Worten: Es handelt sich um die Lücke zwischen der aktuellen Zufriedenheit der Stakeholder mit einem Produkt und der Zufriedenheit, die sie erreichen könnten.
 
-Governance bezieht sich auf Strukturen, Standards, Vorschriften, Normen, Prozesse und Praktiken, die die Ausrichtung, Entscheidungsfindung und Verantwortlichkeit eines Produkts bewusst einschränken und lenken. Governance fördert Transparenz und leitet die Einhaltung von Standards in Bezug auf Wert, Realisierbarkeit und Professionalität. Sie bietet Mechanismen zum Management von Risiken und zur Anpassung des Produkts an sich ändernde Anforderungen oder Umgebungen und unterstützt so dessen Langlebigkeit und Weiterentwicklung. Für eine erfolgreiche Einführung von Scrum ist es entscheidend, dass die Governance mit Scrum im Einklang steht, z. B. durch einen einzigen Ansprechpartner pro Governance-Bereich, der bewusst mit dem Scrum-Team in Bezug auf Qualität und Compliance interagiert, regelmäßige Überprüfung und Anpassung der Governance und keine Überraschungen.
+Governance bezieht sich auf Strukturen, Standards, Vorschriften, Normen, Prozesse und Praktiken, die die Ausrichtung, Entscheidungsfindung und Verantwortlichkeit eines Produkts bewusst einschränken und lenken. Governance fördert Transparenz und leitet die Einhaltung von Standards in Bezug auf Wert, Realisierbarkeit und Professionalität. Sie bietet Mechanismen zum Management von Risiken und zur Anpassung des Produkts an sich ändernde Anforderungen oder Umgebungen und unterstützt so dessen Langlebigkeit und Weiterentwicklung. Für eine erfolgreiche Einführung von Scrum ist es entscheidend, dass die Governance mit Scrum im Einklang steht, z. B. durch einen einzigen Ansprechpartner pro Governance-Bereich, der bewusst mit dem Scrum Team in Bezug auf Qualität und Compliance interagiert, regelmäßige Überprüfung und Anpassung der Governance und keine Überraschungen.
 
 ### Unterstützer {#supporter}
 
-Unterstützer sind eine bestimmte Art von Stakeholdern. Unterstützer sind Stakeholder und Change Agents. Unterstützer sind oft Teil einer starken Führungskoalition (83), die inspiriert und demotivierende Faktoren beseitigt. Unterstützer helfen dem Scrum-Team, erfolgreich zu sein, und beeinflussen die Arbeitsabläufe, Prozesse, Systeme, Produkte, Dienstleistungen und das Arbeitsumfeld der Organisation, damit diese mit der Einführung und Entwicklung von Scrum in Einklang stehen (71). Unterstützer sollten sich bei Bedarf oder auf Anfrage einbringen. Die Wertschöpfung erfordert oft eine effektive und konstruktive Zusammenarbeit mit anderen Stakeholdern.
+Unterstützer sind eine bestimmte Art von Stakeholdern. Unterstützer sind Stakeholder und Change Agents. Unterstützer sind oft Teil einer starken Führungskoalition (83), die inspiriert und demotivierende Faktoren beseitigt. Unterstützer helfen dem Scrum Team, erfolgreich zu sein, und beeinflussen die Arbeitsabläufe, Prozesse, Systeme, Produkte, Dienstleistungen und das Arbeitsumfeld der Organisation, damit diese mit der Einführung und Entwicklung von Scrum in Einklang stehen (71). Unterstützer sollten sich bei Bedarf oder auf Anfrage einbringen. Die Wertschöpfung erfordert oft eine effektive und konstruktive Zusammenarbeit mit anderen Stakeholdern.
 
-Je nach Größe der Organisation sind Beispiele für Unterstützer (unter anderem) Kollegen, Entscheidungsträger, Geldgeber, Governance-Aufsicht, Manager, Fachexperten, Marketing, Personalwesen, Finanzwesen, Beschaffung und Early Adopters. Unterstützer, die Scrum-Teams nicht befähigen, das zu tun, was in diesem Dokument empfohlen wird, sind keine echten Unterstützer. Führungskräfte und Vorstandsmitglieder spielen eine entscheidende Rolle bei der Förderung eines Klimas, in dem Unterstützer Unterstützung leisten. Unterstützer sollten Führungsqualitäten zeigen, die das Scrum-Team schätzt.
+Je nach Größe der Organisation sind Beispiele für Unterstützer (unter anderem) Kollegen, Entscheidungsträger, Geldgeber, Governance-Aufsicht, Manager, Fachexperten, Marketing, Personalwesen, Finanzwesen, Beschaffung und Early Adopters. Unterstützer, die Scrum Teams nicht befähigen, das zu tun, was in diesem Dokument empfohlen wird, sind keine echten Unterstützer. Führungskräfte und Vorstandsmitglieder spielen eine entscheidende Rolle bei der Förderung eines Klimas, in dem Unterstützer Unterstützung leisten. Unterstützer sollten Führungsqualitäten zeigen, die das Scrum Team schätzt.
 
 ### Künstliche Intelligenz {#artificial-intelligence}
 
-Künstliche Intelligenz (KI) wird zunehmend Teil der Arbeitsumgebung und kann die Fähigkeiten eines Scrum-Teams in den Bereichen Entdeckung, Entscheidungsfindung, Produktentwicklung und Wertrealisierung erheblich erweitern.
+Künstliche Intelligenz (KI) wird zunehmend Teil der Arbeitsumgebung und kann die Fähigkeiten eines Scrum Teams in den Bereichen Entdeckung, Entscheidungsfindung, Produktentwicklung und Wertrealisierung erheblich erweitern.
 
 KI kann Scrum durch folgende Aspekte verbessern:
 
 - Empirische Prozesssteuerung (64-66): KI-gesteuerte Analysen verbessern Transparenz, Überprüfung und Anpassung.
-- Kognitive Erweiterung: KI ermöglicht es den menschlichen Mitgliedern des Scrum-Teams, sich auf strategische, kreative und ethische Überlegungen zu konzentrieren.
+- Kognitive Erweiterung: KI ermöglicht es den menschlichen Mitgliedern des Scrum Teams, sich auf strategische, kreative und ethische Überlegungen zu konzentrieren.
 - Kontinuierliche Wertanpassung: KI könnte Produkt-Backlog-Einträge anhand von Live-Feedback und Trends der Nutzer aktualisieren und neu priorisieren.
 - Systemeinblicke: KI identifiziert versteckte Abhängigkeiten und verbessert so die datengestützte Entscheidungsfindung.
 
-Die Möglichkeiten sind endlos. Scrum-Teams könnten KI nutzen, um:
+Die Möglichkeiten sind endlos. Scrum Teams könnten KI nutzen, um:
 
 - Unklarheiten im Text aufzudecken und ihre eigenen Empfehlungen und Ergebnisse kontinuierlich auf Voreingenommenheit, Fehler und unbeabsichtigte Folgen zu überprüfen.
 - Modelle und Anwendungen regelmäßig zu validieren und anzupassen.
@@ -367,29 +367,29 @@ Die Möglichkeiten sind endlos. Scrum-Teams könnten KI nutzen, um:
 - Agenten als KI-Teammitglieder zu schaffen.
 - KI kann hilfreich sein, um bestehende Denkweisen bewusst zu testen und zu hinterfragen.
 
-Die Gefahren sind ebenfalls unbegrenzt. Behalten Sie eine klare menschliche Verantwortung für alle Ergebnisse (geleitet von den Verantwortlichkeiten aus Scrum) bei und nutzen Sie KI als leistungsstarken, aber überwachten Partner bei der Entscheidungsfindung. Dies wird als „Human in the Loop“ bezeichnet. KI kann zwar Innovation und Effektivität zu geringsten Kosten verbessern, ersetzt jedoch nicht die menschliche Verantwortung. KI sollte die empirische Prozesskontrolle (64-66) und ethische (57) Entscheidungsfindung von Scrum unterstützen, nicht außer Kraft setzen. Das Scrum-Team bleibt verantwortlich für die Lieferung wertvoller Ergebnisse, die Bewertung von Beweisen und die Wahrung der Professionalität.
+Die Gefahren sind ebenfalls unbegrenzt. Behalten Sie eine klare menschliche Verantwortung für alle Ergebnisse (geleitet von den Verantwortlichkeiten aus Scrum) bei und nutzen Sie KI als leistungsstarken, aber überwachten Partner bei der Entscheidungsfindung. Dies wird als „Human in the Loop“ bezeichnet. KI kann zwar Innovation und Effektivität zu geringsten Kosten verbessern, ersetzt jedoch nicht die menschliche Verantwortung. KI sollte die empirische Prozesskontrolle (64-66) und ethische (57) Entscheidungsfindung von Scrum unterstützen, nicht außer Kraft setzen. Das Scrum Team bleibt verantwortlich für die Lieferung wertvoller Ergebnisse, die Bewertung von Beweisen und die Wahrung der Professionalität.
 
 KI kann ein unterstützendes Werkzeug sein, wenn sie mit guter Absicht eingesetzt wird. KI-Tools sollten wie jeder andere Faktor bewertet werden, der zum psychologischen Flow (70) und zum Lernen beiträgt: Verbessern sie Feedback-Schleifen? Helfen sie dabei, Annahmen schneller zu validieren? Handeln sie, und wenn ja, handelt es sich um ethisches (57) Handeln?
 
 Psychologischer Flow (70) ist ein Zustand völliger Versunkenheit und Freude an einer Tätigkeit, in dem Handeln und Bewusstsein verschmelzen und die Zeit anders zu vergehen scheint.
 
-Scrum ermutigt das Scrum-Team, verantwortungsbewusst mit KI zu experimentieren, indem es kleine, manchmal reversible Versuche durchführt. Anpassung und Überprüfung gelten nicht nur für das Produkt, sondern auch für die Art und Weise, wie KI in die Lieferung integriert wird.
+Scrum ermutigt das Scrum Team, verantwortungsbewusst mit KI zu experimentieren, indem es kleine, manchmal reversible Versuche durchführt. Anpassung und Überprüfung gelten nicht nur für das Produkt, sondern auch für die Art und Weise, wie KI in die Lieferung integriert wird.
 
 Der Schwerpunkt sollte weiterhin auf der menschlichen Dynamik der Teamarbeit und Zusammenarbeit liegen, wobei KI als potenzielles Hilfsmittel positioniert ist.
 
-### Produktentwickler {#product-developer}
+### Product Developer {#product-developer}
 
-„Produktentwickler” ist eine Rolle und eine Verantwortung. Alle Produktentwickler zusammen sollten über alle Fähigkeiten verfügen, die zur Erstellung von Inkrementen erforderlich sind. Die kombinierten Fähigkeiten werden oft als funktionsübergreifend bezeichnet.
+„Product Developer” ist eine Rolle und eine Verantwortung. Alle Product Developer zusammen sollten über alle Fähigkeiten verfügen, die zur Erstellung von Inkrementen erforderlich sind. Die kombinierten Fähigkeiten werden oft als funktionsübergreifend bezeichnet.
 
-Ein Produktentwickler kann ein Mensch oder ein automatisierter Prozess sein. Menschliche Produktentwickler sind verpflichtet, in jedem Sprint alle Aspekte eines releasbaren Inkrements zu erstellen, zu recherchieren, zu überprüfen und anzupassen. Ihr Hauptaugenmerk liegt auf dem aktuellen Sprint. Ein Teil ihrer Kapazität wird oft in zukunftsorientierte Verfeinerungen und die Untersuchung von Ergebnisfeedback, Nebenwirkungen oder anderen Erkenntnissen investiert.
+Ein Product Developer kann ein Mensch oder ein automatisierter Prozess sein. Menschliche Product Developer sind verpflichtet, in jedem Sprint alle Aspekte eines releasbaren Inkrements zu erstellen, zu recherchieren, zu überprüfen und anzupassen. Ihr Hauptaugenmerk liegt auf dem aktuellen Sprint. Ein Teil ihrer Kapazität wird oft in zukunftsorientierte Verfeinerungen und die Untersuchung von Ergebnisfeedback, Nebenwirkungen oder anderen Erkenntnissen investiert.
 
-Produktentwickler halten sich an die Definition von „Output Done” und streben nach einer Nettoverbesserung. Die Produktentwickler erzielen die besten Ergebnisse, wenn sie sich ausschließlich auf ein Produkt konzentrieren. Wenn der Produkt Owner oder Scrum Master zu einem gegebenen Zeitpunkt aktiv an Einträgen im Sprint Backlog arbeitet, führen sie diese Arbeit als Produktentwickler aus.
+Product Developer halten sich an die Definition von „Output Done” und streben nach einer Nettoverbesserung. Die Product Developer erzielen die besten Ergebnisse, wenn sie sich ausschließlich auf ein Produkt konzentrieren. Wenn der Produkt Owner oder Scrum Master zu einem gegebenen Zeitpunkt aktiv an Einträgen im Sprint Backlog arbeitet, führen sie diese Arbeit als Product Developer aus.
 
-Die Produktentwickler sollten je nach Situation geeignete Verhaltensweisen anwenden, darunter (aber nicht ausschließlich) die eines Mitarbeiters, eines Schöpfers und eines Verfechters von technischer Qualität, Entdeckung, Lieferung und Wertvalidierung.
+Die Product Developer sollten je nach Situation geeignete Verhaltensweisen anwenden, darunter (aber nicht ausschließlich) die eines Mitarbeiters, eines Schöpfers und eines Verfechters von technischer Qualität, Entdeckung, Lieferung und Wertvalidierung.
 
-_Mindestens ein Produktentwickler sollte ein Mensch sein._ Mehrere menschliche Produktentwickler verbessern oft die kognitive Vielfalt, was bei der Bewältigung von Komplexität hilfreich ist.
+_Mindestens ein Product Developer sollte ein Mensch sein._ Mehrere menschliche Product Developer verbessern oft die kognitive Vielfalt, was bei der Bewältigung von Komplexität hilfreich ist.
 
-Produktentwickler sind immer gemeinsam verantwortlich für:
+Product Developer sind immer gemeinsam verantwortlich für:
 
 - Erstellung eines spontanen Plans im Sprint-Backlog zur Erreichung des Sprint-Ziels;
 - Sicherstellung der Qualität durch Einhaltung und Verbesserung der Definition of Output Done;
@@ -399,15 +399,15 @@ Produktentwickler sind immer gemeinsam verantwortlich für:
 - Gegenseitige Rechenschaftspflicht als Fachleute; und
 - Nettoverbesserung.
 
-Der Kontext ist wichtig, es ist entscheidend, die spezifischen Umstände zu berücksichtigen. Als Faustregel gilt jedoch, dass ein Produktentwickler, der weder willens noch bereit oder in der Lage ist, ein Profi zu sein, als Produktentwickler zurücktreten sollte.
+Der Kontext ist wichtig, es ist entscheidend, die spezifischen Umstände zu berücksichtigen. Als Faustregel gilt jedoch, dass ein Product Developer, der weder willens noch bereit oder in der Lage ist, ein Profi zu sein, als Product Developer zurücktreten sollte.
 
 ### Produkt Owner {#product-owner}
 
-Produkt Owner ist eine Rolle und eine Verantwortung. Der Produkt Owner muss ein Mensch sein. Um effektiv zu sein, sollte der Produkt Owner eine Führungskraft für das Produkt sein. Der Produkt Owner maximiert den langfristigen Wert und muss wissen, wo der Wert liegt und wann er benötigt wird. Vom Produkt Owner wird erwartet, dass er auf allen Ebenen und in allen relevanten Geschäftsbereichen arbeitet. Der Produkt Owner arbeitet mit Stakeholdern, dem Scrum Master und den Produktentwicklern zusammen, um Wert zu schaffen.
+Produkt Owner ist eine Rolle und eine Verantwortung. Der Produkt Owner muss ein Mensch sein. Um effektiv zu sein, sollte der Produkt Owner eine Führungskraft für das Produkt sein. Der Produkt Owner maximiert den langfristigen Wert und muss wissen, wo der Wert liegt und wann er benötigt wird. Vom Produkt Owner wird erwartet, dass er auf allen Ebenen und in allen relevanten Geschäftsbereichen arbeitet. Der Produkt Owner arbeitet mit Stakeholdern, dem Scrum Master und den Product Developern zusammen, um Wert zu schaffen.
 
 Der Product Owner verwendet das Product Backlog, um zu definieren, was in welcher ungefähren Reihenfolge entwickelt wird. Der Product Owner behält stets das Produktziel im Auge; sein Hauptaugenmerk liegt darauf, in jedem Schritt den langfristigen Wert zu maximieren.
 
-Der Product Owner wird nicht durch das Analysieren und Verfassen detaillierter Product Backlog-Einträge definiert. Jede Minute, in der man den Produktentwicklern nicht vertraut, ist eine verpasste Chance, strategischer zu denken, mehr mit den Stakeholdern zusammenzuarbeiten oder mehr Wert zu schaffen. Der Product Owner sollte je nach Situation angemessen handeln. Dazu gehören unter anderem (aber nicht ausschließlich) die Rolle als Visionär, Kundenvertreter, Mitarbeiter, Einflussnehmer, Experimentator, Entscheidungsträger und Verfechter der Einbindung von Stakeholdern, der Klarheit, der Produktqualität und der Wertrealisierung.
+Der Product Owner wird nicht durch das Analysieren und Verfassen detaillierter Product Backlog-Einträge definiert. Jede Minute, in der man den Product Developern nicht vertraut, ist eine verpasste Chance, strategischer zu denken, mehr mit den Stakeholdern zusammenzuarbeiten oder mehr Wert zu schaffen. Der Product Owner sollte je nach Situation angemessen handeln. Dazu gehören unter anderem (aber nicht ausschließlich) die Rolle als Visionär, Kundenvertreter, Mitarbeiter, Einflussnehmer, Experimentator, Entscheidungsträger und Verfechter der Einbindung von Stakeholdern, der Klarheit, der Produktqualität und der Wertrealisierung.
 
 Der Product Owner ist immer verantwortlich für:
 
@@ -427,13 +427,13 @@ Der Product Owner ist immer verantwortlich für:
 - Förderung der hochwertigen Schaffung, Entdeckung, Lieferung und Validierung von Wert; und
 - Weitere Produktmanagement-Aktivitäten nach Bedarf.
 
-Der Product Owner kann die oben genannten Aufgaben selbst übernehmen oder mit dem Scrum-Team zusammenarbeiten, um die Verantwortlichkeiten für die Ausführung der oben genannten Aufgaben gegenseitig zu vereinbaren. Unabhängig davon bleibt der Product Owner verantwortlich.
+Der Product Owner kann die oben genannten Aufgaben selbst übernehmen oder mit dem Scrum Team zusammenarbeiten, um die Verantwortlichkeiten für die Ausführung der oben genannten Aufgaben gegenseitig zu vereinbaren. Unabhängig davon bleibt der Product Owner verantwortlich.
 
 Damit Product Owner erfolgreich sein können, sollten alle Stakeholder und Unterstützer ihre Entscheidungen respektieren. Diese Entscheidungen sind im Inhalt und in der Reihenfolge des Product Backlogs sowie durch das überprüfbare Inkrement beim Sprint Review sichtbar. Der Product Owner hat von der Organisation Befugnisse übertragen bekommen.
 
-Die Produktverantwortung erfordert ausgeprägte Produktmanagement- und Fachkenntnisse. Ein Produkt Owner, dem diese Fähigkeiten fehlen, benötigt möglicherweise Unterstützung und Anleitung, bis er die erforderlichen Fachkenntnisse erworben hat. Der Kontext spielt eine Rolle. Als Faustregel gilt jedoch, dass ein Product Owner, der weder willens, bereit noch in der Lage ist, Produktmanagement-Fähigkeiten zu erwerben, als Product Owner zurücktreten sollte. Ein Fachexperte ist nicht unbedingt die beste Wahl für einen Product Owner, da Produktmanagement-Fähigkeiten und Führungsqualitäten erforderlich sind; beispielsweise ist die Verantwortung des Produktentwicklers oft besser geeignet.
+Die Produktverantwortung erfordert ausgeprägte Produktmanagement- und Fachkenntnisse. Ein Produkt Owner, dem diese Fähigkeiten fehlen, benötigt möglicherweise Unterstützung und Anleitung, bis er die erforderlichen Fachkenntnisse erworben hat. Der Kontext spielt eine Rolle. Als Faustregel gilt jedoch, dass ein Product Owner, der weder willens, bereit noch in der Lage ist, Produktmanagement-Fähigkeiten zu erwerben, als Product Owner zurücktreten sollte. Ein Fachexperte ist nicht unbedingt die beste Wahl für einen Product Owner, da Produktmanagement-Fähigkeiten und Führungsqualitäten erforderlich sind; beispielsweise ist die Verantwortung des Product Developers oft besser geeignet.
 
-Wenn das Scrum-Team unklugerweise an mehreren Produkten, Plattformen oder Projekten arbeitet, sollte jeder Produkt-, Plattform- oder Projektmanager ein Stakeholder (und Supporter) des Produkt-Owners sein und zusammenarbeiten, um den langfristigen Wert zu maximieren. Scrum ermutigt das Scrum-Team, fokussiert und engagiert zu bleiben, damit es wertvolle Ergebnisse liefern und die Fallstricke vermeiden kann, die mit der Arbeit als „Feature-Fabrik” verbunden sind.
+Wenn das Scrum Team unklugerweise an mehreren Produkten, Plattformen oder Projekten arbeitet, sollte jeder Produkt-, Plattform- oder Projektmanager ein Stakeholder (und Supporter) des Produkt-Owners sein und zusammenarbeiten, um den langfristigen Wert zu maximieren. Scrum ermutigt das Scrum Team, fokussiert und engagiert zu bleiben, damit es wertvolle Ergebnisse liefern und die Fallstricke vermeiden kann, die mit der Arbeit als „Feature-Fabrik” verbunden sind.
 
 Der Product Owner ist eine Person, kein Ausschuss oder eine Technologie. Wer das Product Backlog ändern möchte, muss den Product Owner davon überzeugen. Der Product Owner maximiert den langfristigen Wert und geht dabei oft Kompromisse ein.
 
@@ -448,24 +448,24 @@ Der Scrum Master ist verantwortlich für die Effektivität des Scrum Teams, der 
 Der Scrum Master unterstützt das Scrum Team, den Product Owner und die Unterstützer auf verschiedene Weise, darunter:
 
 - Allen hilft, die Scrum-Theorie und -Praxis zu verstehen, und bei Bedarf schult oder coacht;
-- Das Scrum-Team und die Unterstützer in die Lage versetzt, sich auf vielfältige Weise kontinuierlich zu verbessern;
+- Das Scrum Team und die Unterstützer in die Lage versetzt, sich auf vielfältige Weise kontinuierlich zu verbessern;
 - Zeitnahe, zielgerichtete und bewusste Interaktionen fördert;
-- Sicherstellt, dass das Scrum-Team über eine geeignete Definition von „Output Done“ verfügt;
+- Sicherstellt, dass das Scrum Team über eine geeignete Definition von „Output Done“ verfügt;
 - Sicherstellt, dass alle Scrum-Events stattfinden, konstruktiv und produktiv sind und innerhalb des Zeitrahmens bleiben;
 - Beseitigung von Hindernissen für die produktbezogene Arbeit und die effektive Einführung von Scrum;
 - Coaching in Richtung Selbstmanagement (49) und Funktionsübergreifender Zusammenarbeit;
-- Unterstützung des Scrum-Teams, der Stakeholder und der Unterstützer beim Verständnis ihrer Bedeutung für die Unterstützung hochwertiger Inkremente, die die Definition des fertigen Outputs im Hinblick auf das Produktziel und die Definition des fertigen Ergebnisses erfüllen;
+- Unterstützung des Scrum Teams, der Stakeholder und der Unterstützer beim Verständnis ihrer Bedeutung für die Unterstützung hochwertiger Inkremente, die die Definition des fertigen Outputs im Hinblick auf das Produktziel und die Definition des fertigen Ergebnisses erfüllen;
 - Verbesserung der Anpassungsfähigkeit (80) und Optimierung des Wertflusses;
 - Förderung von evidenzbasiertem Vertrauen, aber mit Mitgefühl und zeitnah, um Überheblichkeit zu vermeiden;
-- Förderung der Veränderungsbereitschaft und der allgemeinen Handlungsfähigkeit des Scrum-Teams und der Unterstützer;
-- Förderung hilfreicher Verhaltensweisen innerhalb des Scrum-Teams, die mit den Scrum-Werten im Einklang stehen, um Vertrauen, Zusammenarbeit und hohe Leistung zu fördern; und
-- Förderung des Scrum-Teams, wertvolle Arbeit zu leisten, Feedback einzuholen und bei Bedarf schnell und häufig Nachbesserungen vorzunehmen.
+- Förderung der Veränderungsbereitschaft und der allgemeinen Handlungsfähigkeit des Scrum Teams und der Unterstützer;
+- Förderung hilfreicher Verhaltensweisen innerhalb des Scrum Teams, die mit den Scrum-Werten im Einklang stehen, um Vertrauen, Zusammenarbeit und hohe Leistung zu fördern; und
+- Förderung des Scrum Teams, wertvolle Arbeit zu leisten, Feedback einzuholen und bei Bedarf schnell und häufig Nachbesserungen vorzunehmen.
 
 Der Scrum Master unterstützt das Scrum Team auf verschiedene Weise, darunter:
 
 - Unterstützung des Scrum Teams bei seiner Bildung, Weiterqualifizierung und kontinuierlichen Verbesserung;
 - Unterstützung des Scrum Teams beim Verständnis der Notwendigkeit klarer und prägnanter Product Backlog Einträge, die einen Mehrwert liefern; und
-- darauf zu achten, dass das gesamte Scrum-Team zielgerichtet und bewusst miteinander und mit den Stakeholdern zusammenarbeitet, die Definition der fertigen Outputs einhält und sich auf die Schaffung hochwertiger Inkremente gemäß der Definition der fertigen Ergebnisse konzentriert.
+- darauf zu achten, dass das gesamte Scrum Team zielgerichtet und bewusst miteinander und mit den Stakeholdern zusammenarbeitet, die Definition der fertigen Outputs einhält und sich auf die Schaffung hochwertiger Inkremente gemäß der Definition der fertigen Ergebnisse konzentriert.
 
 Der Scrum Master unterstützt den Product Owner auf verschiedene Weise, darunter:
 
@@ -503,11 +503,11 @@ Scrum Master können sich mit anderen Scrum Mastern oder Supportern zusammenschl
 
 Der Scrum Master ist eine Person, kein Ausschuss oder eine Technologie, und dient dem Produkt Owner, dem Scrum Team, den Stakeholdern und der gesamten Organisation. Als Change Agent und Führungskraft sollte der Scrum Master generell alle Personen zur Teilnahme an der Veränderung einladen. Es ist hilfreich, wenn der Scrum Master über Kenntnisse des Wertflusses (68,69), Lean (63), der Komplexitätstheorie (30-35) und anderer unterstützender und ergänzender Theorien in diesem Dokument verfügt und Menschen beim „Wie” unterstützt. Es ist auch hilfreich, wenn der Scrum Master unermüdlich ist und einen unstillbaren Hunger nach Lernen und Veränderung hat.
 
-Scrum Master zu sein ist eine Berufung, bei der es Belohnung genug ist, anderen zum Erfolg zu verhelfen. Ein Scrum Master steht nicht im Rampenlicht. Wie jeder gute Leiter gibt er anderen Anerkennung und übernimmt Verantwortung, wenn etwas schief läuft. Eine längere Verbleibdauer in dieser Rolle hilft dabei, das Scrum-Team zu seinem vollen Potenzial zu führen, jedoch nur, wenn die Produktentwickler gemeinsam Selbstmanagement entwickeln. Ein elterliches Verhalten des Scrum Masters fördert kein selbst-gemanagtes Scrum-Team. Der Kontext ist wichtig. Als Faustregel gilt jedoch, dass ein Scrum Master, der weder willens, bereit noch in der Lage ist, als Motor des Wandels zu fungieren, sein Amt als Scrum Master niederlegen sollte.
+Scrum Master zu sein ist eine Berufung, bei der es Belohnung genug ist, anderen zum Erfolg zu verhelfen. Ein Scrum Master steht nicht im Rampenlicht. Wie jeder gute Leiter gibt er anderen Anerkennung und übernimmt Verantwortung, wenn etwas schief läuft. Eine längere Verbleibdauer in dieser Rolle hilft dabei, das Scrum Team zu seinem vollen Potenzial zu führen, jedoch nur, wenn die Product Developer gemeinsam Selbstmanagement entwickeln. Ein elterliches Verhalten des Scrum Masters fördert kein selbst-gemanagtes Scrum Team. Der Kontext ist wichtig. Als Faustregel gilt jedoch, dass ein Scrum Master, der weder willens, bereit noch in der Lage ist, als Motor des Wandels zu fungieren, sein Amt als Scrum Master niederlegen sollte.
 
 ## Die Scrum-Artefakte im Erweiterungspaket {#the-scrum-artifacts-in-the-expansion-pack}
 
-Die Artefakte von Scrum sorgen für Transparenz darüber, was das Scrum-Team und die Stakeholder für wertvoll halten. So haben alle die gleiche Grundlage für die Überprüfung und Anpassung.
+Die Artefakte von Scrum sorgen für Transparenz darüber, was das Scrum Team und die Stakeholder für wertvoll halten. So haben alle die gleiche Grundlage für die Überprüfung und Anpassung.
 
 Jedes Artefakt enthält eine Verpflichtung:
 
@@ -530,7 +530,7 @@ Eine Erfahrung ist eine spezifische Lösung, die darauf ausgelegt ist, die Bedü
 
 Eine Plattform ist eine architektonische Vorrichtung, eine grundlegende Infrastruktur oder eine Reihe von Tools, die es Entwicklern ermöglichen, Produkte zu erstellen, um eine Erfahrung bereitzustellen. Plattformen bieten eine Basis für die Entwicklung mehrerer Produkte, wobei der Schwerpunkt eher auf Skalierbarkeit, Zuverlässigkeit und Flexibilität für Ingenieure als auf der direkten Interaktion mit dem Nutzer liegt.
 
-Das Scrum-Team und die Stakeholder müssen jederzeit ein klares Verständnis davon haben, was das Produkt ist, wer die Kunden, Nutzer oder Entscheidungsträger sind und um welche Art von Produkt es sich handelt – z. B. für Endnutzer, Mitarbeiter oder Scrum-Teams –, da es unterschiedliche Stakeholder und Wege der Wertschöpfung gibt. Ein Produkt ist evolutionär und oft langlebig. Das Produkt benötigt ein einziges Product Backlog, um die Transparenz zu erhöhen und den Wert zu maximieren.
+Das Scrum Team und die Stakeholder müssen jederzeit ein klares Verständnis davon haben, was das Produkt ist, wer die Kunden, Nutzer oder Entscheidungsträger sind und um welche Art von Produkt es sich handelt – z. B. für Endnutzer, Mitarbeiter oder Scrum Teams –, da es unterschiedliche Stakeholder und Wege der Wertschöpfung gibt. Ein Produkt ist evolutionär und oft langlebig. Das Produkt benötigt ein einziges Product Backlog, um die Transparenz zu erhöhen und den Wert zu maximieren.
 
 Der Kontext ist wichtig. Als Faustregel gilt jedoch, dass ein Produkt, um Traktion zu schaffen und aufrechtzuerhalten, folgende Eigenschaften aufweisen sollte:
 
@@ -555,7 +555,7 @@ Bevorzugen Sie direkte Beweise gegenüber Indizienbeweisen. Zum Beispiel:
 - Nutzerergebnisse könnten sich auf spezifische Veränderungen im Nutzerverhalten beziehen, die Probleme lösen und die Nutzererfahrung verbessern, wie z. B. die effizientere Erledigung von Aufgaben oder die Nutzung neuer Funktionen.
 - Ergebnisse für Produkt-Stakeholder könnten diese Verhaltensänderungen mit Produktleistungsmetriken verknüpfen, z. B. Trends bei Produktkunden, Metriken für Entscheidungsträger/Nutzer, Zeit bis zur Produktfreigabe, Zeit bis zum Erlernen der Nutzung, Zeit bis zur Umstellung usw.
 - Ergebnisse für die Stakeholder des Unternehmens, z. B. Compliance, langfristige Kostensenkungen, Geschäftsergebnisse, Trends bei den Marktanteilen, Kundenzufriedenheit für alle Produkte, Zeit bis zur Markteinführung, Einarbeitungszeit, Zeit bis zur Umstellung usw.
-- Ergebnisse für das Scrum-Team, z. B. verbesserte technische Fähigkeiten (psychologischer Flow (70), Häufigkeit der Releases, Tools, Fähigkeiten, technische Schulden, UX- oder CX-Schulden, Kapazität), Klima/Kultur für Nettoverbesserungen und Innovationen.
+- Ergebnisse für das Scrum Team, z. B. verbesserte technische Fähigkeiten (psychologischer Flow (70), Häufigkeit der Releases, Tools, Fähigkeiten, technische Schulden, UX- oder CX-Schulden, Kapazität), Klima/Kultur für Nettoverbesserungen und Innovationen.
 
 User eXperience (UX) oder Customer eXperience (CX) Schulden sind die Summe aller – beabsichtigten oder unbeabsichtigten – Entscheidungen in Bezug auf Design und Implementierung, die ein Produkt oder eine Dienstleistung für Nutzer oder Kunden weniger benutzerfreundlich, angenehm oder effektiv machen. Das Erkennen, Verfolgen und Beheben dieser Schulden ist unerlässlich, um Produkte zu liefern, die den Bedürfnissen und Erwartungen der Nutzer wirklich entsprechen.
 
@@ -573,51 +573,51 @@ Ein Inkrementkandidat qualifiziert sich erst dann als Inkrement, wenn er den Qua
 
 Die Definition des fertigen Outputs ist eine Verpflichtung. Sie beschreibt formal die Qualitätsmaßstäbe, die die Sorgfaltspflicht für das Inkrement zum Ausdruck bringen, damit es an die Stakeholder geliefert werden kann.
 
-Die Definition der fertigen Leistung umfasst in der Regel (ist jedoch nicht beschränkt auf) sowohl technische Standards als auch Produktqualitäten. Das Scrum-Team erstellt sie, sofern sie nicht von der Organisation als Mindestanforderung vorgegeben ist. Wenn mehrere Scrum-Teams an demselben Produkt arbeiten, verwenden sie dieselbe Definition der fertigen Leistung als gemeinsame Grundlage, können diese jedoch verbessern.
+Die Definition der fertigen Leistung umfasst in der Regel (ist jedoch nicht beschränkt auf) sowohl technische Standards als auch Produktqualitäten. Das Scrum Team erstellt sie, sofern sie nicht von der Organisation als Mindestanforderung vorgegeben ist. Wenn mehrere Scrum Teams an demselben Produkt arbeiten, verwenden sie dieselbe Definition der fertigen Leistung als gemeinsame Grundlage, können diese jedoch verbessern.
 
-Das Scrum-Team ist verpflichtet, die Definition der fertigen Leistung einzuhalten und kontinuierlich zu verbessern. Das Inkrement ist kumulativ. Die Definition der fertigen Outputs dient dem Wohl des Produkts und seiner Stakeholder. Die Definition der fertigen Outputs ist der allgemeine Qualitätsstandard für das gesamte Inkrement, nicht der spezifische Standard für jeden einzelnen Eintrag (z. B. Akzeptanzkriterien).
+Das Scrum Team ist verpflichtet, die Definition der fertigen Leistung einzuhalten und kontinuierlich zu verbessern. Das Inkrement ist kumulativ. Die Definition der fertigen Outputs dient dem Wohl des Produkts und seiner Stakeholder. Die Definition der fertigen Outputs ist der allgemeine Qualitätsstandard für das gesamte Inkrement, nicht der spezifische Standard für jeden einzelnen Eintrag (z. B. Akzeptanzkriterien).
 
 Ein freigegebenes Inkrement ermöglicht Ergebnisfeedback für die Validierung des Werts der Definition der fertigen Ergebnisse.
 
 ### Produkt-Backlog {#product-backlog}
 
-Das Product Backlog ist ein Artefakt. Es ist die sich herausbildende, geordnete (sequenzierte) Liste der Product Backlog Items, die zur Erreichung des Produktziels erforderlich sind. Das Product Backlog sorgt für Transparenz (Klarheit der Arbeit) und ist die einzige Arbeitsquelle für das Scrum-Team, um das Produktziel zu erreichen. Der Product Owner, der stets den Wert im Auge behält, leitet die Reihenfolge der Product Backlog Items im Product Backlog. Ein kleineres Product Backlog sorgt oft für mehr Transparenz.
+Das Product Backlog ist ein Artefakt. Es ist die sich herausbildende, geordnete (sequenzierte) Liste der Product Backlog Items, die zur Erreichung des Produktziels erforderlich sind. Das Product Backlog sorgt für Transparenz (Klarheit der Arbeit) und ist die einzige Arbeitsquelle für das Scrum Team, um das Produktziel zu erreichen. Der Product Owner, der stets den Wert im Auge behält, leitet die Reihenfolge der Product Backlog Items im Product Backlog. Ein kleineres Product Backlog sorgt oft für mehr Transparenz.
 
 #### Produkt-Backlog-Eintrag {#product-backlog-item}
 
 Ein Produkt-Backlog-Eintrag ist ein potenziell wertvoller Eintrag im Produkt-Backlog. Er hat nicht unbedingt ein bestimmtes Format. Er dient dazu, ein Problem oder eine Chance zu behandeln. Er kann zusätzlich zur Definition der fertigen Ausgabe auch Akzeptanzkriterien enthalten, anhand derer festgestellt werden kann, wann die Arbeit abgeschlossen ist. Es kann vorkommen, dass genau das geliefert wird, was angefordert wurde, aber dennoch keine ausreichenden Ergebnisse erzielt werden. Daher kann ein Product Backlog Item zusätzlich zu den bereits in der Definition of Outcome Done enthaltenen Kriterien auch klar definierte Outcome Criteria enthalten, anhand derer festgestellt werden kann, wann ein ausreichender Wert geliefert wurde.
 
-Ein Produkt-Backlog-Eintrag ist eine einzelne Arbeit, die einen Wert entdeckt oder liefert. Ein Produkt-Backlog-Eintrag kann sich jederzeit weiterentwickeln, auch während die Produktentwickler daran arbeiten. Während der Verfeinerung wird er in kleinere, besser verständliche (vor allem für das Scrum-Team) Produkt-Backlog-Einträge aufgeteilt, die einen Wert liefern könnten. Gelegentlich kann es vorkommen, dass ein Eintrag im Product Backlog nicht mit dem Produktziel in Zusammenhang steht. Wenn dies häufig vorkommt, sollte überprüft werden, ob die _Fokus_ebene möglicherweise nicht dort liegt, wo sie sein sollte. Das Scrum-Team und die Stakeholder sollten sich auf Ergebnisse statt auf Outputs _fokussieren_, die richtige Balance zwischen den verschiedenen Aspekten wahren und vermeiden, dass das Scrum-Team zu einer „Feature-Fabrik” oder „Entdeckungsfabrik” wird.
+Ein Produkt-Backlog-Eintrag ist eine einzelne Arbeit, die einen Wert entdeckt oder liefert. Ein Produkt-Backlog-Eintrag kann sich jederzeit weiterentwickeln, auch während die Product Developer daran arbeiten. Während der Verfeinerung wird er in kleinere, besser verständliche (vor allem für das Scrum Team) Produkt-Backlog-Einträge aufgeteilt, die einen Wert liefern könnten. Gelegentlich kann es vorkommen, dass ein Eintrag im Product Backlog nicht mit dem Produktziel in Zusammenhang steht. Wenn dies häufig vorkommt, sollte überprüft werden, ob die _Fokus_ebene möglicherweise nicht dort liegt, wo sie sein sollte. Das Scrum Team und die Stakeholder sollten sich auf Ergebnisse statt auf Outputs _fokussieren_, die richtige Balance zwischen den verschiedenen Aspekten wahren und vermeiden, dass das Scrum Team zu einer „Feature-Fabrik” oder „Entdeckungsfabrik” wird.
 
 #### Akzeptanzkriterien {#acceptance-criteria}
 
-Akzeptanzkriterien beschreiben, sofern vorhanden, zusätzlich zur Definition der fertigen Outputs, wann ein Output für einen bestimmten Eintrag im Product Backlog fertig ist. Akzeptanzkriterien in verfeinerten Einträgen sollten eindeutig klarstellen, was verlangt wird. Akzeptanzkriterien umfassen Kriterien, die für einen Product Backlog-Eintrag spezifisch sind und nicht bereits in der Definition der fertigen Ausgabe behandelt wurden; sie können funktional oder nicht funktional sein. Akzeptanzkriterien können sich jederzeit weiterentwickeln, auch während die Produktentwickler daran arbeiten.
+Akzeptanzkriterien beschreiben, sofern vorhanden, zusätzlich zur Definition der fertigen Outputs, wann ein Output für einen bestimmten Eintrag im Product Backlog fertig ist. Akzeptanzkriterien in verfeinerten Einträgen sollten eindeutig klarstellen, was verlangt wird. Akzeptanzkriterien umfassen Kriterien, die für einen Product Backlog-Eintrag spezifisch sind und nicht bereits in der Definition der fertigen Ausgabe behandelt wurden; sie können funktional oder nicht funktional sein. Akzeptanzkriterien können sich jederzeit weiterentwickeln, auch während die Product Developer daran arbeiten.
 
 #### Ergebnis-Kriterien {#outcome-criteria}
 
-Ergebnis-Kriterien, sofern vorhanden, beschreiben die Absicht des Product Backlog-Eintrags; sie sind das „Warum” hinter dem „Was”. Die Erfüllung der Ergebnis-Kriterien ergänzt oft die Definition des fertigen Ergebnisses für das Produkt. Sie können Kriterien enthalten, die für einen Produkt-Backlog-Eintrag spezifisch sind und in der Definition des fertigen Ergebnisses noch nicht berücksichtigt wurden. Wenn Fragen auftauchen, geben die Ergebnis-Kriterien Orientierung; sie können in Form einer Beschreibung oder von Maßnahmen vorliegen, idealerweise Letzteres. Ergebnis-Kriterien können sich jederzeit weiterentwickeln, auch während die Produktentwickler daran arbeiten.
+Ergebnis-Kriterien, sofern vorhanden, beschreiben die Absicht des Product Backlog-Eintrags; sie sind das „Warum” hinter dem „Was”. Die Erfüllung der Ergebnis-Kriterien ergänzt oft die Definition des fertigen Ergebnisses für das Produkt. Sie können Kriterien enthalten, die für einen Produkt-Backlog-Eintrag spezifisch sind und in der Definition des fertigen Ergebnisses noch nicht berücksichtigt wurden. Wenn Fragen auftauchen, geben die Ergebnis-Kriterien Orientierung; sie können in Form einer Beschreibung oder von Maßnahmen vorliegen, idealerweise Letzteres. Ergebnis-Kriterien können sich jederzeit weiterentwickeln, auch während die Product Developer daran arbeiten.
 
 #### Verfeinerung {#refinement}
 
 Verfeinerung ist eine Aktivität. Sie kann formell (ein zusätzliches Ereignis) oder informell sein. Verfeinerung ist ein fortlaufender, emergenter Prozess, der Klarheit schafft und Risiken reduziert. Sie schafft ausreichend Verständnis und Vertrauen, dass die ausgewählten oder anstehenden Product Backlog Items bereit sind (innerhalb weniger Tage oder noch schneller gemäß der Definition of Output Done abgeschlossen werden können). Dabei werden verschiedene Arten von Abhängigkeiten berücksichtigt.
 
-Die Verfeinerung umfasst die Aufteilung der Product Backlog Items in kleinere, besser verständliche (vor allem für das Scrum-Team) Product Backlog Items. Dabei können weitere Details wie Beschreibung, Akzeptanzkriterien, Ergebnis-Kriterien, Reihenfolge und Größe hinzugefügt werden. Die Attribute variieren, sollten aber für das Scrum-Team aussagekräftig sein. Die Verfeinerung kann Recherchen umfassen, einschließlich, aber nicht beschränkt auf die Validierung von Problemen oder Chancen, Benutzer- oder Kundenerfahrungen und die Validierung von Lösungen. Die Produktentwickler und niemand sonst sind für die Dimensionierung der Product Backlog Items verantwortlich. Der Product Owner kann die Produktentwickler beeinflussen, indem er ihnen hilft, potenzielle Kompromisse zu verstehen und auszuwählen.
+Die Verfeinerung umfasst die Aufteilung der Product Backlog Items in kleinere, besser verständliche (vor allem für das Scrum Team) Product Backlog Items. Dabei können weitere Details wie Beschreibung, Akzeptanzkriterien, Ergebnis-Kriterien, Reihenfolge und Größe hinzugefügt werden. Die Attribute variieren, sollten aber für das Scrum Team aussagekräftig sein. Die Verfeinerung kann Recherchen umfassen, einschließlich, aber nicht beschränkt auf die Validierung von Problemen oder Chancen, Benutzer- oder Kundenerfahrungen und die Validierung von Lösungen. Die Product Developer und niemand sonst sind für die Dimensionierung der Product Backlog Items verantwortlich. Der Product Owner kann die Product Developer beeinflussen, indem er ihnen hilft, potenzielle Kompromisse zu verstehen und auszuwählen.
 
-Zu den Teilnehmern gehören häufig Stakeholder und Mitglieder des Scrum-Teams; es ist nicht ungewöhnlich, dass Produktentwickler direkt mit Stakeholdern zusammenarbeiten. Die Verfeinerung wird oft vom Product Owner unterstützt oder moderiert. Der Product Owner kann sich stärker auf die Produktverantwortung konzentrieren, wenn die Produktentwickler über ein umfassendes Verständnis des Produkts verfügen. Im Allgemeinen handelt es sich um eine vorausschauende Aktivität, die Klarheit, Richtung und einen möglichen Fokus für bevorstehende Sprints bietet.
+Zu den Teilnehmern gehören häufig Stakeholder und Mitglieder des Scrum Teams; es ist nicht ungewöhnlich, dass Product Developer direkt mit Stakeholdern zusammenarbeiten. Die Verfeinerung wird oft vom Product Owner unterstützt oder moderiert. Der Product Owner kann sich stärker auf die Produktverantwortung konzentrieren, wenn die Product Developer über ein umfassendes Verständnis des Produkts verfügen. Im Allgemeinen handelt es sich um eine vorausschauende Aktivität, die Klarheit, Richtung und einen möglichen Fokus für bevorstehende Sprints bietet.
 
 #### Verpflichtung: Produktziel {#commitment:-product-goal}
 
-Das Produktziel ist eine Verpflichtung. Es wird durch das Product Backlog dargestellt, das dem Product Owner gehört. Es ist das aktuelle, strategischere und ehrgeizigere Einzelziel (das „Warum”). Es gibt die Richtung für das Produkt vor und ermöglicht den an dem Produkt arbeitenden Produktentwicklern, sich zu fokussieren. Es verbessert die Transparenz, indem es den Produktentwicklern eine klare, wertvolle Richtung vorgibt, auf die sie hinarbeiten können, und zwar mithilfe eines taktischeren Sprintziels (dem „Warum” für den Sprint).
+Das Produktziel ist eine Verpflichtung. Es wird durch das Product Backlog dargestellt, das dem Product Owner gehört. Es ist das aktuelle, strategischere und ehrgeizigere Einzelziel (das „Warum”). Es gibt die Richtung für das Produkt vor und ermöglicht den an dem Produkt arbeitenden Product Developern, sich zu fokussieren. Es verbessert die Transparenz, indem es den Product Developern eine klare, wertvolle Richtung vorgibt, auf die sie hinarbeiten können, und zwar mithilfe eines taktischeren Sprintziels (dem „Warum” für den Sprint).
 
-Ein Produktziel ist das mittelfristige Ziel für das Scrum-Team und die Stakeholder (und Unterstützer). Das Scrum-Team sollte ein Produktziel erfüllen (oder aufgeben), bevor es das nächste in Angriff nimmt.
+Ein Produktziel ist das mittelfristige Ziel für das Scrum Team und die Stakeholder (und Unterstützer). Das Scrum Team sollte ein Produktziel erfüllen (oder aufgeben), bevor es das nächste in Angriff nimmt.
 
 Ein Produktziel ist in der Regel eine noch unbewiesene Aussage über den Wert. Es kann auf verschiedene Weise ausgedrückt werden, beispielsweise als eine Reihe von Hypothesen zur Schließung oder Verringerung von Zufriedenheitslücken. Es sorgt für Ausgewogenheit, indem es sich auf einen Teil der vielfältigen Erwartungen und Grenzen der Stakeholder (einschließlich, aber nicht beschränkt auf Kunden oder Nutzer) konzentriert. Durch Inspektion und Anpassung ist es wichtig, Unsicherheiten (72), Ergebnisfeedback, Nebenwirkungen und andere Erkenntnisse zu akzeptieren.
 
 #### Was ist mit einer Produktvision? {#what-about-a-product-vision}
 
-Viele Unternehmen arbeiten mit einer Produktvision, die dabei hilft, eine mögliche Zukunft zu visualisieren. Das Scrum-Team kann eine Vision als Input für die Überlegungen zum Produktziel nutzen. Eine Produktvision ist eine sinnvolle, langfristige Reihe von wertvollen gewünschten Ergebnissen. Das mittelfristige Produktziel ist oft ein Sprungbrett auf dem Weg zu einer langfristigen Produktvision.
+Viele Unternehmen arbeiten mit einer Produktvision, die dabei hilft, eine mögliche Zukunft zu visualisieren. Das Scrum Team kann eine Vision als Input für die Überlegungen zum Produktziel nutzen. Eine Produktvision ist eine sinnvolle, langfristige Reihe von wertvollen gewünschten Ergebnissen. Das mittelfristige Produktziel ist oft ein Sprungbrett auf dem Weg zu einer langfristigen Produktvision.
 
-Während das Scrum-Team und die Stakeholder das Produktziel überprüfen und anpassen, müssen sie offen für die Idee sein, dass auch die Produktvision oder das Produktziel angepasst werden müssen. Oft werden mehrere Produktziele nacheinander erreicht, während auf eine Vision hingearbeitet wird.
+Während das Scrum Team und die Stakeholder das Produktziel überprüfen und anpassen, müssen sie offen für die Idee sein, dass auch die Produktvision oder das Produktziel angepasst werden müssen. Oft werden mehrere Produktziele nacheinander erreicht, während auf eine Vision hingearbeitet wird.
 
 Wichtig ist, dass eine Produktvision oft ein fiktives Konstrukt ist, von dem möglicherweise nichts wahr ist. Das Aufstellen von Hypothesen und das Durchführen von Experimenten in eine bestimmte Richtung sind unerlässlich und genau hier kann Scrum den größten Mehrwert bieten.
 
@@ -627,33 +627,33 @@ Eine Produktvision ist oft inspirierend, kann aber auch überwältigend sein. Da
 
 Das Sprint-Backlog ist ein Artefakt. Es besteht aus dem Sprint-Ziel (dem „Warum” des Sprints), den für den Sprint ausgewählten Produkt-Backlog-Einträgen (dem „Was”, auch als Prognose bezeichnet) und enthält häufig einen umsetzbaren Plan für die Bereitstellung des Inkrements (dem „Wie”). Es sorgt für Transparenz (Klarheit der Arbeit) während des gesamten Sprints.
 
-Das Sprint-Backlog ist ein Plan von und für die Produktentwickler. Es ist die Sichtweise der Produktentwickler auf die Arbeit, die zur Erreichung des Sprint-Ziels (dem „Warum” des Sprints) erforderlich ist. Nehmen wir ein suboptimales Szenario an, in dem die meisten Einträge im Sprint-Backlog kontinuierlich nichts mit dem Produktziel zu tun haben. In diesem Fall werden die Scrum-Werte „Fokus” und „Verpflichtung” nicht eingehalten.
+Das Sprint-Backlog ist ein Plan von und für die Product Developer. Es ist die Sichtweise der Product Developer auf die Arbeit, die zur Erreichung des Sprint-Ziels (dem „Warum” des Sprints) erforderlich ist. Nehmen wir ein suboptimales Szenario an, in dem die meisten Einträge im Sprint-Backlog kontinuierlich nichts mit dem Produktziel zu tun haben. In diesem Fall werden die Scrum-Werte „Fokus” und „Verpflichtung” nicht eingehalten.
 
-Im Rahmen des Sprint-Ziels aktualisieren die Produktentwickler ihren Plan, sogar die Prognose, während des gesamten Sprints, sobald sie mehr erfahren. Das Sprint-Backlog sollte genügend Arbeit enthalten, um mit der Arbeit beginnen zu können, z. B. mit ein oder zwei Produkt-Backlog-Einträgen, die auf das Sprint-Ziel hinarbeiten. Die Produktentwickler überprüfen ihren Fortschritt in Richtung des Sprint-Ziels im Daily Scrum oder häufiger. Produktentwickler lernen, sich an Unsicherheiten anzupassen und darauf zu reagieren (72).
+Im Rahmen des Sprint-Ziels aktualisieren die Product Developer ihren Plan, sogar die Prognose, während des gesamten Sprints, sobald sie mehr erfahren. Das Sprint-Backlog sollte genügend Arbeit enthalten, um mit der Arbeit beginnen zu können, z. B. mit ein oder zwei Produkt-Backlog-Einträgen, die auf das Sprint-Ziel hinarbeiten. Die Product Developer überprüfen ihren Fortschritt in Richtung des Sprint-Ziels im Daily Scrum oder häufiger. Product Developer lernen, sich an Unsicherheiten anzupassen und darauf zu reagieren (72).
 
 #### Verpflichtung: Sprint-Ziel {#commitment:-sprint-goal}
 
-Das Sprint-Ziel ist eine Verpflichtung, die vom Scrum-Team erstellt wird und diesem gehört. Das Sprint-Ziel ist das einzige einheitliche Ziel des Sprints (das „Warum”) für die Produktentwickler, das in der Sprint-Planung erstellt wird. Die Erreichung des Sprint-Ziels ist eine Verpflichtung der Produktentwickler. Das Sprint-Backlog (einschließlich des „Warum”, des „Was” und oft auch des „Wie”) bietet Fokus und Flexibilität in Bezug auf die sich entwickelnde Arbeit und verbessert so die Transparenz.
+Das Sprint-Ziel ist eine Verpflichtung, die vom Scrum Team erstellt wird und diesem gehört. Das Sprint-Ziel ist das einzige einheitliche Ziel des Sprints (das „Warum”) für die Product Developer, das in der Sprint-Planung erstellt wird. Die Erreichung des Sprint-Ziels ist eine Verpflichtung der Product Developer. Das Sprint-Backlog (einschließlich des „Warum”, des „Was” und oft auch des „Wie”) bietet Fokus und Flexibilität in Bezug auf die sich entwickelnde Arbeit und verbessert so die Transparenz.
 
-Das Sprint-Ziel ermutigt das Scrum-Team, zusammenzuarbeiten, anstatt an separaten Initiativen zu arbeiten. Wenn sich die Arbeit von den Erwartungen der Produktentwickler unterscheidet, arbeiten die Produktentwickler mit dem Produkt Owner zusammen, um innerhalb des Sprints Möglichkeiten auszuhandeln, ohne das Sprint-Ziel zu beeinträchtigen. Niemand sagt den Produktentwicklern, wie sie ihre Arbeit dimensionieren oder ausführen sollen.
+Das Sprint-Ziel ermutigt das Scrum Team, zusammenzuarbeiten, anstatt an separaten Initiativen zu arbeiten. Wenn sich die Arbeit von den Erwartungen der Product Developer unterscheidet, arbeiten die Product Developer mit dem Produkt Owner zusammen, um innerhalb des Sprints Möglichkeiten auszuhandeln, ohne das Sprint-Ziel zu beeinträchtigen. Niemand sagt den Product Developern, wie sie ihre Arbeit dimensionieren oder ausführen sollen.
 
 ## Die Scrum-Ereignisse im Erweiterungspaket {#the-scrum-events-in-the-expansion-pack}
 
 Scrum kombiniert vier zeitlich begrenzte Ereignisse für die Inspektion und Anpassung innerhalb eines fünften Ereignisses von bestimmter Dauer, dem Sprint. Diese Ereignisse unterstützen die Scrum-Säulen Transparenz, Inspektion und Anpassung. Releases ermöglichen idealerweise kontinuierlich einen Mehrwert. Seltene Releases führen zu verzögerten Ergebnisrückmeldungen.
 
-Eine Timebox ist eine festgelegte maximale Zeitspanne vom Beginn bis zum Ende eines definierten Ereignisses, die nicht mit der Erwartung zu verwechseln ist, dass diese Zeit vollständig genutzt wird. Der Zweck einer Timebox in Scrum ist es, die Auswahl der wesentlichen Arbeit zu fördern und einen Fokus zu schaffen, um die gewünschten Ergebnisse schnell zu erreichen. In Scrum ist die Sprintlänge für ein gegebenes Scrum-Team konsistent, sodass es sich nicht um eine Timebox handelt.
+Eine Timebox ist eine festgelegte maximale Zeitspanne vom Beginn bis zum Ende eines definierten Ereignisses, die nicht mit der Erwartung zu verwechseln ist, dass diese Zeit vollständig genutzt wird. Der Zweck einer Timebox in Scrum ist es, die Auswahl der wesentlichen Arbeit zu fördern und einen Fokus zu schaffen, um die gewünschten Ergebnisse schnell zu erreichen. In Scrum ist die Sprintlänge für ein gegebenes Scrum Team konsistent, sodass es sich nicht um eine Timebox handelt.
 
 Events schaffen einen Rhythmus und minimieren den Bedarf an anderen Meetings, die nicht Teil von Scrum sind. Idealerweise findet jedes Event zur gleichen Zeit und am gleichen Ort statt, um die Komplexität zu reduzieren (30-35) und die Bildung von Gewohnheiten zu fördern. Eine geschickte Moderation verbessert die Effektivität. Ineffektive Events bergen die Gefahr, dass der Fokus auf das Sprint-Ziel, das Produktziel, Transparenz, Inspektion, Anpassung und die Scrum-Werte verloren geht.
 
 Jedes Ereignis hat seinen eigenen Zweck und sollte tiefgreifende, sinnvolle Arbeit beinhalten. Zusammen bilden die Scrum-Ereignisse ein Gerüst der Transparenz, um zu überprüfen und anzupassen, zu pausieren und zu reflektieren. Die Scrum-Ereignisse unterstützen strukturiertes Denken und Arbeiten, Effektivität und eine ausgewogene Arbeitsbelastung.
 
-Kommunikation ist der Schlüssel, um sicherzustellen, dass sich das Scrum-Team und die Unterstützer auf das Wesentliche konzentrieren. Abgesehen vom Sprint können Ereignisse weniger Zeit in Anspruch nehmen, solange die Kohärenz nicht verloren geht.
+Kommunikation ist der Schlüssel, um sicherzustellen, dass sich das Scrum Team und die Unterstützer auf das Wesentliche konzentrieren. Abgesehen vom Sprint können Ereignisse weniger Zeit in Anspruch nehmen, solange die Kohärenz nicht verloren geht.
 
 ### Der Sprint {#the-sprint}
 
 Der Sprint ist ein Ereignis, bei dem Ideen in Wert umgewandelt werden. Der Sprint ist das Container-Ereignis. Er ist eine Iteration einer bestimmten Zeitspanne, in der Arbeit ausgeführt wird. Er sorgt für Fokus und Stabilität. Ein Sprint dauert maximal vier Wochen. Ein neuer Sprint beginnt unmittelbar nach Abschluss des vorherigen Sprints. Alle Arbeiten, die zur Erreichung des Produktziels erforderlich sind, finden innerhalb von Sprints statt.
 
-Sprints sind das Herzstück von Scrum, in denen das Scrum-Team Ideen in nutzbare, nützliche und potenziell wertvolle Inkremente umsetzt. Das Inkrement wird so schnell wie möglich veröffentlicht, wobei die Notwendigkeit eines frühzeitigen Feedback zu den Ergebnissen berücksichtigt wird. Wenn ein Teil der Stakeholder (einschließlich, aber nicht beschränkt auf echte Kunden, Entscheidungsträger und Nutzer) keine Veröffentlichung erhält, kann dies zu einem Mangel an zeitnahem Feedback zu den Ergebnissen führen. In einem Sprint können mehrere Inkremente erstellt werden; das Scrum-Team sollte sich bemühen, den Wert durch frühzeitige und häufige Releases zu validieren, sofern dies möglich ist.
+Sprints sind das Herzstück von Scrum, in denen das Scrum Team Ideen in nutzbare, nützliche und potenziell wertvolle Inkremente umsetzt. Das Inkrement wird so schnell wie möglich veröffentlicht, wobei die Notwendigkeit eines frühzeitigen Feedback zu den Ergebnissen berücksichtigt wird. Wenn ein Teil der Stakeholder (einschließlich, aber nicht beschränkt auf echte Kunden, Entscheidungsträger und Nutzer) keine Veröffentlichung erhält, kann dies zu einem Mangel an zeitnahem Feedback zu den Ergebnissen führen. In einem Sprint können mehrere Inkremente erstellt werden; das Scrum Team sollte sich bemühen, den Wert durch frühzeitige und häufige Releases zu validieren, sofern dies möglich ist.
 
 Während des Sprints:
 
@@ -664,7 +664,7 @@ Während des Sprints:
 
 Sprints ermöglichen Ergebnisse, indem sie mindestens alle vier Wochen die Überprüfung und Anpassung des Fortschritts in Richtung eines Sprint-Ziels sicherstellen. Wenn ein Sprint zu lang ist, kann das Sprint-Ziel ungültig werden, was die Komplexität (30-35) und das Risiko erhöht. Kürzere Sprints generieren oft mehr Lernzyklen; sie können auch das Risiko begrenzen.
 
-Kürzere Sprints erfordern in der Regel verbesserte Fähigkeiten (z. B. Verfeinerung, vertikale Aufteilung, technischer Bereich, Geschäftsbereich). Der Kontext ist wichtig, und das Scrum-Team ist bestrebt, das richtige Gleichgewicht zu finden.
+Kürzere Sprints erfordern in der Regel verbesserte Fähigkeiten (z. B. Verfeinerung, vertikale Aufteilung, technischer Bereich, Geschäftsbereich). Der Kontext ist wichtig, und das Scrum Team ist bestrebt, das richtige Gleichgewicht zu finden.
 
 Es gibt verschiedene ergänzende Praktiken zur Bewertung oder Prognose des Fortschritts, wie Burn-Downs, Burn-Ups, Flussanalysen, Monte-Carlo-Wahrscheinlichkeitsprognosen, Large Effort Estimation, Fuzzy Sets (110) usw. Diese sind zwar nützlich, ersetzen jedoch nicht die Bedeutung der Empirie (67). In komplexen (30-35) Umgebungen kann das, was bereits geschehen ist, für zukunftsorientierte Entscheidungen herangezogen werden, aber was passieren wird, ist unbekannt.
 
@@ -674,47 +674,47 @@ Ein Sprint kann abgebrochen werden, wenn das Sprint-Ziel hinfällig wird. Nur de
 
 ### Sprint-Planung {#sprint-planning}
 
-Die Sprint-Planung ist ein Ereignis. Bei diesem ersten Ereignis des Sprints legt das Scrum-Team den Fokus fest und schafft Verbindlichkeit.
+Die Sprint-Planung ist ein Ereignis. Bei diesem ersten Ereignis des Sprints legt das Scrum Team den Fokus fest und schafft Verbindlichkeit.
 
-Während der Sprint-Planung wird das strategischere Produktziel (das „Warum” für das Product Backlog) berücksichtigt und gibt die Richtung vor. Dabei erstellen die Produktentwickler das Sprint-Backlog, das aus dem kurzfristigen, eher taktischen Sprint-Ziel (dem „Warum” für den Sprint), den ursprünglich identifizierten Arbeiten und dem Plan für die Umsetzung besteht.
+Während der Sprint-Planung wird das strategischere Produktziel (das „Warum” für das Product Backlog) berücksichtigt und gibt die Richtung vor. Dabei erstellen die Product Developer das Sprint-Backlog, das aus dem kurzfristigen, eher taktischen Sprint-Ziel (dem „Warum” für den Sprint), den ursprünglich identifizierten Arbeiten und dem Plan für die Umsetzung besteht.
 
 Die Sprint-Planung befasst sich mit den folgenden Themen:
 
 #### Das „Warum” für den Sprint {#the-why-for-the-sprint}
 
-Der Product Owner schlägt Ideen vor, wie das Produkt im aktuellen Sprint seinen Wert und Nutzen steigern könnte. Das Scrum-Team definiert dann gemeinsam ein Sprint-Ziel, das den Stakeholdern vermittelt, warum der Sprint für das Produktziel wertvoll ist. Das Sprint-Ziel muss bis zum Ende der Sprint-Planung festgelegt sein.
+Der Product Owner schlägt Ideen vor, wie das Produkt im aktuellen Sprint seinen Wert und Nutzen steigern könnte. Das Scrum Team definiert dann gemeinsam ein Sprint-Ziel, das den Stakeholdern vermittelt, warum der Sprint für das Produktziel wertvoll ist. Das Sprint-Ziel muss bis zum Ende der Sprint-Planung festgelegt sein.
 
 #### Das „Was” für das „Warum” {#the-what-toward-the-why}
 
-In Zusammenarbeit mit dem Product Owner wählen die Produktentwickler Einträge aus dem Product Backlog aus, die in den aktuellen Sprint aufgenommen werden sollen. Das Scrum-Team kann diese Einträge verfeinern, was das Verständnis und das Vertrauen erhöht. Die ausgewählten Einträge sollten gemäß dem Standard der Definition of Output Done zusammen mit anderen Einträgen erreichbar sein.
+In Zusammenarbeit mit dem Product Owner wählen die Product Developer Einträge aus dem Product Backlog aus, die in den aktuellen Sprint aufgenommen werden sollen. Das Scrum Team kann diese Einträge verfeinern, was das Verständnis und das Vertrauen erhöht. Die ausgewählten Einträge sollten gemäß dem Standard der Definition of Output Done zusammen mit anderen Einträgen erreichbar sein.
 
-Die Auswahl der innerhalb eines Sprints zu erledigenden Aufgaben kann eine Herausforderung sein. Je mehr die Produktentwickler jedoch über ihre bisherigen Leistungen, vertikale Aufteilung, bevorstehende Kapazitäten und die Definition der fertigen Ergebnisse wissen, desto sicherer können sie die Ergebnisse des Sprints vorhersagen.
+Die Auswahl der innerhalb eines Sprints zu erledigenden Aufgaben kann eine Herausforderung sein. Je mehr die Product Developer jedoch über ihre bisherigen Leistungen, vertikale Aufteilung, bevorstehende Kapazitäten und die Definition der fertigen Ergebnisse wissen, desto sicherer können sie die Ergebnisse des Sprints vorhersagen.
 
-Erfolgreiche Scrum-Teams überlasten sich nicht. Tatsächlich planen sie, die Arbeit frühzeitig zu erledigen, und nutzen manchmal einen Puffer für unerwartete Ereignisse (85). Dies hilft dem Scrum-Team, fokussiert zu bleiben, die Qualität zu verbessern und die Stakeholder durch eine schnellere Wertlieferung zufrieden zu stellen. Chronische Überlastung oder plötzliche Veränderungen können zu übermäßigem negativem Stress führen, den Jeff Sutherland als „Bayesianische Überraschung” bezeichnet. Sie können den psychologischen Fluss (70) und die Leistung des Scrum-Teams stören. Eine klare Kommunikation, ein professioneller Umgang mit unerwarteten Ereignissen (71) und kleine, regelmäßige Änderungen tragen dazu bei, dies zu verhindern, sodass Scrum-Teams eine frühzeitige Lieferung anstreben sollten.
+Erfolgreiche Scrum Teams überlasten sich nicht. Tatsächlich planen sie, die Arbeit frühzeitig zu erledigen, und nutzen manchmal einen Puffer für unerwartete Ereignisse (85). Dies hilft dem Scrum Team, fokussiert zu bleiben, die Qualität zu verbessern und die Stakeholder durch eine schnellere Wertlieferung zufrieden zu stellen. Chronische Überlastung oder plötzliche Veränderungen können zu übermäßigem negativem Stress führen, den Jeff Sutherland als „Bayesianische Überraschung” bezeichnet. Sie können den psychologischen Fluss (70) und die Leistung des Scrum Teams stören. Eine klare Kommunikation, ein professioneller Umgang mit unerwarteten Ereignissen (71) und kleine, regelmäßige Änderungen tragen dazu bei, dies zu verhindern, sodass Scrum Teams eine frühzeitige Lieferung anstreben sollten.
 
 #### Das „Wie” für das „Was” {#the-how-for-the-what}
 
-Wie die Arbeit erledigt wird, liegt allein im Ermessen der Produktentwickler. Niemand sonst sagt den Produktentwicklern, wie sie ihre Arbeit zu erledigen haben. Die Produktentwickler wählen ihre Arbeit selbst aus; niemand sonst weist den Produktentwicklern Product Backlog Items zu oder drängt sie ihnen auf, nicht einmal der Product Owner.
+Wie die Arbeit erledigt wird, liegt allein im Ermessen der Product Developer. Niemand sonst sagt den Product Developern, wie sie ihre Arbeit zu erledigen haben. Die Product Developer wählen ihre Arbeit selbst aus; niemand sonst weist den Product Developern Product Backlog Items zu oder drängt sie ihnen auf, nicht einmal der Product Owner.
 
 Die Sprint-Planung ist auf maximal acht Stunden für einen vierwöchigen Sprint begrenzt. Bei kürzeren Sprints ist die Veranstaltung in der Regel kürzer. Der Kontext spielt eine Rolle. Als Faustregel gilt jedoch, dass Sie genügend Planung vornehmen sollten, um mit der Arbeit beginnen zu können, z. B. planen Sie einige Product Backlog Items für das Sprint-Ziel.
 
 ### Tägliches Scrum {#daily-scrum}
 
-Das tägliche Scrum ist ein Ereignis. Beim täglichen Scrum arbeiten die Produktentwickler gemeinsam an den Fortschritten in Richtung des Sprint-Ziels und aktualisieren den umsetzbaren Plan, das Sprint-Backlog, bis zum nächsten täglichen Scrum. Falls das Sprint-Ziel bereits erreicht wurde, arbeiten die Produktentwickler gemeinsam an sinnvollen Fortschritten in Richtung des Produktziels.
+Das tägliche Scrum ist ein Ereignis. Beim täglichen Scrum arbeiten die Product Developer gemeinsam an den Fortschritten in Richtung des Sprint-Ziels und aktualisieren den umsetzbaren Plan, das Sprint-Backlog, bis zum nächsten täglichen Scrum. Falls das Sprint-Ziel bereits erreicht wurde, arbeiten die Product Developer gemeinsam an sinnvollen Fortschritten in Richtung des Produktziels.
 
-Das Daily Scrum sorgt für Fokus, Zusammenhalt und Dringlichkeit und fördert das Selbstmanagement (49). In der Regel nehmen nur die Produktentwickler daran teil. Der Einfachheit halber findet es oft im gleichen Rhythmus, am gleichen Ort und zur gleichen Zeit statt.
+Das Daily Scrum sorgt für Fokus, Zusammenhalt und Dringlichkeit und fördert das Selbstmanagement (49). In der Regel nehmen nur die Product Developer daran teil. Der Einfachheit halber findet es oft im gleichen Rhythmus, am gleichen Ort und zur gleichen Zeit statt.
 
-Die Produktentwickler können die Struktur und die Techniken frei wählen. Daily Scrums verbessern die Kommunikation zur Erreichung des Sprint-Ziels, identifizieren und beseitigen Risiken und Hindernisse, fördern schnelle Entscheidungen und machen andere Meetings überflüssig.
+Die Product Developer können die Struktur und die Techniken frei wählen. Daily Scrums verbessern die Kommunikation zur Erreichung des Sprint-Ziels, identifizieren und beseitigen Risiken und Hindernisse, fördern schnelle Entscheidungen und machen andere Meetings überflüssig.
 
-Das Daily Scrum ist nicht der einzige Zeitpunkt, zu dem die Produktentwickler ihren Plan für den Sprint im Kontext des Sprint-Ziels oder Produktziels anpassen. Produktentwickler treffen sich oft mehrmals am Tag zu detaillierteren Besprechungen.
+Das Daily Scrum ist nicht der einzige Zeitpunkt, zu dem die Product Developer ihren Plan für den Sprint im Kontext des Sprint-Ziels oder Produktziels anpassen. Product Developer treffen sich oft mehrmals am Tag zu detaillierteren Besprechungen.
 
-Um den Wertfluss (68,69) zu ermöglichen und potenzielle Ergebnisse schneller zu erzielen, sollten sich die Produktentwickler auf jeweils einen oder wenige Einträge konzentrieren und die Definition of Output Done erfüllen, bevor sie mit der Arbeit an anderen Einträgen beginnen. Die Produktentwickler können dies erreichen, indem sie sich konzentrieren, weniger Einträge bearbeiten und bereits begonnene Arbeiten proaktiv abschließen, anstatt neue Arbeiten zu beginnen. Die Produktentwickler überwachen nicht die Leerlaufzeiten der Mitarbeiter, sondern die Leerlaufzeiten der Arbeit.
+Um den Wertfluss (68,69) zu ermöglichen und potenzielle Ergebnisse schneller zu erzielen, sollten sich die Product Developer auf jeweils einen oder wenige Einträge konzentrieren und die Definition of Output Done erfüllen, bevor sie mit der Arbeit an anderen Einträgen beginnen. Die Product Developer können dies erreichen, indem sie sich konzentrieren, weniger Einträge bearbeiten und bereits begonnene Arbeiten proaktiv abschließen, anstatt neue Arbeiten zu beginnen. Die Product Developer überwachen nicht die Leerlaufzeiten der Mitarbeiter, sondern die Leerlaufzeiten der Arbeit.
 
 Das Daily Scrum ist auf maximal fünfzehn Minuten pro Tag begrenzt; es kann auch kürzer sein.
 
 ### Sprint Review {#sprint-review}
 
-Das Sprint Review ist ein Ereignis. Es handelt sich um eine interaktive, kollaborative Arbeitssitzung. Häufig teilt das Scrum-Team das aktuelle Produktziel mit und präsentiert den Stakeholdern die Definition der fertigen Outputs und die Definition der fertigen Ergebnisse. Das Scrum-Team teilt die Ergebnisse seiner Arbeit mit, welche Kompromisse eingegangen wurden und wie viel Fortschritt in Richtung des Produktziels erzielt wurde (das Warum hinter der Arbeit). Falls verfügbar, werden aktuelle und auf dem neuesten Stand befindliche Messgrößen für den Fortschritt in Richtung der Definition der fertigen Ergebnisse geteilt und berücksichtigt.
+Das Sprint Review ist ein Ereignis. Es handelt sich um eine interaktive, kollaborative Arbeitssitzung. Häufig teilt das Scrum Team das aktuelle Produktziel mit und präsentiert den Stakeholdern die Definition der fertigen Outputs und die Definition der fertigen Ergebnisse. Das Scrum Team teilt die Ergebnisse seiner Arbeit mit, welche Kompromisse eingegangen wurden und wie viel Fortschritt in Richtung des Produktziels erzielt wurde (das Warum hinter der Arbeit). Falls verfügbar, werden aktuelle und auf dem neuesten Stand befindliche Messgrößen für den Fortschritt in Richtung der Definition der fertigen Ergebnisse geteilt und berücksichtigt.
 
 Der Sprint Review überprüft viele Dinge im Zusammenhang mit dem Produkt, wie z. B. das Produktziel, das Product Backlog, das Sprintziel, die gewonnenen Erkenntnisse, das Inkrement, die Erwartungen und Grenzen der Stakeholder, das Feedback zu den Ergebnissen, Nebenwirkungen, den Fortschritt mit dem Produkt, den Markt sowie zukunftsorientierte Aspekte, z. B. welche neuen Ideen und Möglichkeiten sich ergeben haben und mögliche nächste Schritte.
 
@@ -732,7 +732,7 @@ Die Sprint-Review ist das vorletzte Ereignis des Sprints und ist auf maximal vie
 
 ### Sprint-Retrospektive {#sprint-retrospective}
 
-Die Sprint-Retrospektive ist ein Ereignis. Bei diesem Ereignis einigt sich das Scrum-Team darauf, wie es sich verbessern kann. Dabei werden auch falsche Annahmen untersucht, d. h. Annahmen, die das Scrum-Team in die falsche Richtung geführt haben. Gute Dinge wie bestimmte Technologien, Prozesse, Muster usw. können ebenfalls hervorgehoben oder bekräftigt werden. Die untersuchten Elemente variieren oft je nach Arbeitsbereich. Reflexion ist in einer psychologisch sicheren Umgebung effektiver.
+Die Sprint-Retrospektive ist ein Ereignis. Bei diesem Ereignis einigt sich das Scrum Team darauf, wie es sich verbessern kann. Dabei werden auch falsche Annahmen untersucht, d. h. Annahmen, die das Scrum Team in die falsche Richtung geführt haben. Gute Dinge wie bestimmte Technologien, Prozesse, Muster usw. können ebenfalls hervorgehoben oder bekräftigt werden. Die untersuchten Elemente variieren oft je nach Arbeitsbereich. Reflexion ist in einer psychologisch sicheren Umgebung effektiver.
 
 Die Sprint-Retrospektive konzentriert sich auf die hilfreichsten Veränderungen zur Verbesserung, wie z. B.:
 
@@ -741,26 +741,26 @@ Die Sprint-Retrospektive konzentriert sich auf die hilfreichsten Veränderungen 
 - Professionalität, z. B. Fähigkeiten, technische Praktiken, Werkzeuge, Innovationsfähigkeit;
 - Fluss validierter Werte (68,69), z. B. End-to-End-Flussmetriken, Time-to-Market;
 - Effektivität (das „Wie”), z. B. Technologie, Prozesse, Abhängigkeiten;
-- Interaktionen und Dynamik des Scrum-Teams, z. B. Zusammenarbeit, Arbeitsvereinbarungen;
+- Interaktionen und Dynamik des Scrum Teams, z. B. Zusammenarbeit, Arbeitsvereinbarungen;
 - Informationsradiatoren, z. B. Produktwand, Metriken;
 - Die Definition des fertigen Outputs für zukünftige Sprints;
 - Weitere Anpassungen der Definition des fertigen Ergebnisses für zukünftige Sprints;
 - Wie lassen sich die Maßnahmen zur Definition des fertigen Ergebnisses automatisch erreichen?
 - Und vieles mehr.
 
-Die wirkungsvollsten Verbesserungen sollten so schnell wie möglich umgesetzt werden. Das Scrum-Team sollte nicht nur über Verbesserungen sprechen, denn Scrum basiert auf sinnvollen, kontinuierlichen Verbesserungen. Einige Verbesserungsmaßnahmen erfordern die Unterstützung von Supportern, was jedoch nicht bedeutet, dass das Scrum-Team nicht trotzdem nach einer Nettoverbesserung streben sollte (z. B. kontinuierliche marginale Gewinne).
+Die wirkungsvollsten Verbesserungen sollten so schnell wie möglich umgesetzt werden. Das Scrum Team sollte nicht nur über Verbesserungen sprechen, denn Scrum basiert auf sinnvollen, kontinuierlichen Verbesserungen. Einige Verbesserungsmaßnahmen erfordern die Unterstützung von Supportern, was jedoch nicht bedeutet, dass das Scrum Team nicht trotzdem nach einer Nettoverbesserung streben sollte (z. B. kontinuierliche marginale Gewinne).
 
 Die Sprint-Retrospektive schließt den Sprint ab. Sie ist auf maximal drei Stunden für einen vierwöchigen Sprint begrenzt. Bei kürzeren Sprints ist die Veranstaltung in der Regel kürzer.
 
-## Multi-Scrum-Team-Produkte {#multi-scrum-team-products}
+## Multi-Scrum Team-Produkte {#multi-Scrum Team-products}
 
-Wenn ein Scrum-Team zu groß wird, sollte es eine Umstrukturierung in mehrere zusammenhängende Scrum-Teams in Betracht ziehen, die sich jeweils auf dasselbe Produkt konzentrieren. Mehrere Scrum-Teams, die am selben Produkt arbeiten, sollten dasselbe Produktziel, denselben Product Backlog, denselben Product Owner, dieselbe Basisdefinition für „Ergebnis fertig“ und dieselbe Basisdefinition für „Output fertig“ haben.
+Wenn ein Scrum Team zu groß wird, sollte es eine Umstrukturierung in mehrere zusammenhängende Scrum Teams in Betracht ziehen, die sich jeweils auf dasselbe Produkt konzentrieren. Mehrere Scrum Teams, die am selben Produkt arbeiten, sollten dasselbe Produktziel, denselben Product Backlog, denselben Product Owner, dieselbe Basisdefinition für „Ergebnis fertig“ und dieselbe Basisdefinition für „Output fertig“ haben.
 
-Seien Sie vorsichtig mit der blinden Annahme, dass mehr Scrum-Teams mehr Wert schaffen. Skalieren Sie nur, wenn die Vorteile die zusätzlichen Kosten eindeutig überwiegen. Bevor Sie skalieren, muss das einzelne Scrum-Team in der Lage sein, in jedem Sprint zuverlässig ein Inkrement zu produzieren. Wenn Sie jedoch skalieren müssen, verwenden Sie einen Ansatz, der mit diesem Dokument übereinstimmt. Oft führen weniger Teams zu mehr Ergebnissen.
+Seien Sie vorsichtig mit der blinden Annahme, dass mehr Scrum Teams mehr Wert schaffen. Skalieren Sie nur, wenn die Vorteile die zusätzlichen Kosten eindeutig überwiegen. Bevor Sie skalieren, muss das einzelne Scrum Team in der Lage sein, in jedem Sprint zuverlässig ein Inkrement zu produzieren. Wenn Sie jedoch skalieren müssen, verwenden Sie einen Ansatz, der mit diesem Dokument übereinstimmt. Oft führen weniger Teams zu mehr Ergebnissen.
 
-In einem Multi-Scrum-Team-Kontext können Scrum-Teams die Abhängigkeiten zwischen den Scrum-Teams reduzieren, indem sie durch Zusammenarbeit, gegenseitige Befruchtung, Wissenstransfer und gezielte Interaktionen funktionsübergreifender werden. Die erforderlichen spezifischen Fähigkeiten sind oft breit gefächert und variieren je nach Arbeitsbereich. In einer Multi-Scrum-Team-Umgebung werden zielgerichtete und bewusste Interaktionen sowie Professionalität (einschließlich kontinuierlicher Integration) noch wichtiger.
+In einem Multi-Scrum Team-Kontext können Scrum Teams die Abhängigkeiten zwischen den Scrum Teams reduzieren, indem sie durch Zusammenarbeit, gegenseitige Befruchtung, Wissenstransfer und gezielte Interaktionen funktionsübergreifender werden. Die erforderlichen spezifischen Fähigkeiten sind oft breit gefächert und variieren je nach Arbeitsbereich. In einer Multi-Scrum Team-Umgebung werden zielgerichtete und bewusste Interaktionen sowie Professionalität (einschließlich kontinuierlicher Integration) noch wichtiger.
 
-In einer Konfiguration mit einem Produkt Owner und einem Scrum-Team könnte der Produkt Owner ein Produktmanager, Marketingdirektor, Technologiedirektor usw. sein. In einer Multi-Scrum-Team-Konfiguration für ein Produkt ist idealerweise immer noch nur ein Produkt Owner vorgesehen, der als Leiter für das Produkt fungieren sollte. Damit der Product Owner mehrere Scrum-Teams für dasselbe Produkt betreuen kann, übernimmt er oft eine strategischere Rolle und delegiert Probleme und Chancen an die Produktentwickler, darunter beispielsweise Aspekte des Produktdesigns oder des Produktmanagements.
+In einer Konfiguration mit einem Produkt Owner und einem Scrum Team könnte der Produkt Owner ein Produktmanager, Marketingdirektor, Technologiedirektor usw. sein. In einer Multi-Scrum Team-Konfiguration für ein Produkt ist idealerweise immer noch nur ein Produkt Owner vorgesehen, der als Leiter für das Produkt fungieren sollte. Damit der Product Owner mehrere Scrum Teams für dasselbe Produkt betreuen kann, übernimmt er oft eine strategischere Rolle und delegiert Probleme und Chancen an die Product Developer, darunter beispielsweise Aspekte des Produktdesigns oder des Produktmanagements.
 
 Das Product Backlog ist ein Werkzeug zur Erhöhung der Transparenz.
 
@@ -769,23 +769,23 @@ Im Allgemeinen gilt: Je weniger Product Backlogs pro Produkt, implizit (wie ein 
 - Je weniger Silos im Produkt, desto größer die Transparenz über das gesamte Produkt hinweg.
 - Je transparenter die Verfolgung des Gesamtfortschritts über das gesamte Produkt hinweg, desto besser.
 - Je klarer der Gesamtwert über das gesamte Produkt hinweg, desto besser.
-- Je wahrscheinlicher ist es, dass ein Scrum-Team weiß, dass es aus Produktsicht an Einträgen mit geringem Wert arbeitet.
+- Je wahrscheinlicher ist es, dass ein Scrum Team weiß, dass es aus Produktsicht an Einträgen mit geringem Wert arbeitet.
 - Je wahrscheinlicher ist es, dass Verbesserungen bei der Wertschöpfung beobachtet werden. Und
-- Je strategischer der Produkt Owner wird, indem er produktübergreifende Arbeit an die Produktentwickler delegiert.
+- Je strategischer der Produkt Owner wird, indem er produktübergreifende Arbeit an die Product Developer delegiert.
 
-Weniger Produkt-Backlogs pro Produkt sind besser für die Anpassungsfähigkeit (80), aber ohne befähigte Eigenverantwortung, eine kohärente Kontrollspanne oder direkten Kontakt zu den relevanten Stakeholdern entstehen Lücken. Scrum fördert ein Klima für Zufälle und Multi-Learning, da verschiedene Personen und Scrum-Teams zusammenarbeiten und Entdeckungen und Erkenntnisse geteilt und genutzt werden können. Dies ist in einer Umgebung, in der jede Komponente über ein isoliertes Produkt-Backlog verfügt, eher unwahrscheinlich.
+Weniger Produkt-Backlogs pro Produkt sind besser für die Anpassungsfähigkeit (80), aber ohne befähigte Eigenverantwortung, eine kohärente Kontrollspanne oder direkten Kontakt zu den relevanten Stakeholdern entstehen Lücken. Scrum fördert ein Klima für Zufälle und Multi-Learning, da verschiedene Personen und Scrum Teams zusammenarbeiten und Entdeckungen und Erkenntnisse geteilt und genutzt werden können. Dies ist in einer Umgebung, in der jede Komponente über ein isoliertes Produkt-Backlog verfügt, eher unwahrscheinlich.
 
-Zufälle im Zusammenhang mit „The New New Product Development Game” (29) bedeuten, dass nützliche Ideen oder Lösungen manchmal durch Zufall und nicht durch sorgfältige Planung entstehen. Wenn Scrum-Teams eng zusammenarbeiten und Informationen austauschen, entdecken sie möglicherweise neue Ansätze oder Antworten, einfach weil sie offen für unerwartete Ereignisse oder zufällige Entdeckungen sind.
+Zufälle im Zusammenhang mit „The New New Product Development Game” (29) bedeuten, dass nützliche Ideen oder Lösungen manchmal durch Zufall und nicht durch sorgfältige Planung entstehen. Wenn Scrum Teams eng zusammenarbeiten und Informationen austauschen, entdecken sie möglicherweise neue Ansätze oder Antworten, einfach weil sie offen für unerwartete Ereignisse oder zufällige Entdeckungen sind.
 
 Multi-Learning bedeutet, dass Teammitglieder gleichzeitig auf viele verschiedene Arten lernen. Sie eignen sich neue Fähigkeiten und Kenntnisse nicht nur in ihrem eigenen Bereich an, sondern auch in anderen Bereichen, und sie lernen als Einzelpersonen, als Gruppe und als Teil des gesamten Unternehmens. Dies hilft dem Team, flexibler zu werden und eine Vielzahl von Problemen schnell zu lösen, da alle voneinander und aus ihren Erfahrungen lernen, während sie zusammenarbeiten.
 
-Die richtige Balance zu finden, ist ein Dilemma. Es gibt immer Kompromisse zu berücksichtigen. Eine gute Faustregel lautet jedoch: Je weniger implizite oder explizite Produkt-Backlogs, desto besser – ermöglicht durch Multi-Learning und den organisationalen Transfer von Wissen zwischen Scrum-Teams, Abteilungen und Produkten.
+Die richtige Balance zu finden, ist ein Dilemma. Es gibt immer Kompromisse zu berücksichtigen. Eine gute Faustregel lautet jedoch: Je weniger implizite oder explizite Produkt-Backlogs, desto besser – ermöglicht durch Multi-Learning und den organisationalen Transfer von Wissen zwischen Scrum Teams, Abteilungen und Produkten.
 
 Der organisatorische Lerntransfer, wie er in „The New New Product Development Game” (29) beschrieben wird, ist der Prozess, durch den Wissen und Erkenntnisse, die in einem neuen Produktentwicklungsbereich gewonnen werden, regelmäßig geteilt und auf nachfolgende Bereiche oder andere Abteilungen innerhalb der Organisation übertragen werden.
 
-Organisationen sind oft auf einfache Verwaltung statt auf einfache Ergebnisse ausgelegt. Fragen Sie sich, wie viele Scrum-Teams ein Problem oder eine Chance betrifft, um einen Mehrwert zu erzielen. Im Allgemeinen gilt: Je geringer diese Zahl ist, desto besser.
+Organisationen sind oft auf einfache Verwaltung statt auf einfache Ergebnisse ausgelegt. Fragen Sie sich, wie viele Scrum Teams ein Problem oder eine Chance betrifft, um einen Mehrwert zu erzielen. Im Allgemeinen gilt: Je geringer diese Zahl ist, desto besser.
 
-Befreien Sie Teams von Befehls- und Kontrollstrukturen. Entscheiden Sie sich lieber für abgestimmte Autonomie. Fördern Sie zielgerichtete, bewusste Interaktionen innerhalb und zwischen selbst-gemanagten Scrum-Teams (49). Schaffen Sie ein Arbeitsklima mit minimalen, aber ausreichenden Managementprozessen, Rahmenbedingungen und Grenzen. Gleichen Sie die Erwartungen und Grenzen der Stakeholder aus und fördern Sie sie. Bauen Sie Veränderungskompetenz und kontinuierliche Verbesserung in einer Richtung auf, nicht nur die Lieferung, und machen Sie dies zu einer Gewohnheit.
+Befreien Sie Teams von Befehls- und Kontrollstrukturen. Entscheiden Sie sich lieber für abgestimmte Autonomie. Fördern Sie zielgerichtete, bewusste Interaktionen innerhalb und zwischen selbst-gemanagten Scrum Teams (49). Schaffen Sie ein Arbeitsklima mit minimalen, aber ausreichenden Managementprozessen, Rahmenbedingungen und Grenzen. Gleichen Sie die Erwartungen und Grenzen der Stakeholder aus und fördern Sie sie. Bauen Sie Veränderungskompetenz und kontinuierliche Verbesserung in einer Richtung auf, nicht nur die Lieferung, und machen Sie dies zu einer Gewohnheit.
 
 Im Zweifelsfall sollten Sie sich mit dem New New Product Development Game (29) befassen, das Gute an den aktuellen Neuerungen annehmen, aber alle Vorstellungen von einem Industriekomplex (30-35) ablehnen, in dem nur mutige Menschen die Möglichkeit haben, etwas zu bewegen.
 
@@ -817,37 +817,37 @@ Scrum wird im [2020 Scrum Guide](https://scrumguides.org/) (40) beschrieben. Scr
 
 **Warum Scrum verwenden?**
  
-Scrum ermöglicht es Scrum-Teams, Emergenz (71) zu identifizieren, darzustellen oder zu messen, Unsicherheiten zu akzeptieren, auf Veränderungen zu reagieren, häufig Werte zu liefern und zu validieren sowie sich kontinuierlich zu verbessern. Scrum fördert die Zusammenarbeit, Verantwortlichkeit und evidenzbasierte Entscheidungsfindung und sorgt so für bestmögliche Ergebnisse in einem sich schnell verändernden Umfeld. selbst-gemanagte Scrum-Teams, die sich an Werten orientieren, sind entscheidend für kreative Problemlösungen und die Nutzung von Chancen; nicht selbst-gemanagte Scrum-Teams behindern die Fähigkeit, mit Komplexität umzugehen (30-35). selbst-gemanagte Scrum-Teams sind nicht zu verwechseln mit individueller Selbst-Management.
+Scrum ermöglicht es Scrum Teams, Emergenz (71) zu identifizieren, darzustellen oder zu messen, Unsicherheiten zu akzeptieren, auf Veränderungen zu reagieren, häufig Werte zu liefern und zu validieren sowie sich kontinuierlich zu verbessern. Scrum fördert die Zusammenarbeit, Verantwortlichkeit und evidenzbasierte Entscheidungsfindung und sorgt so für bestmögliche Ergebnisse in einem sich schnell verändernden Umfeld. selbst-gemanagte Scrum Teams, die sich an Werten orientieren, sind entscheidend für kreative Problemlösungen und die Nutzung von Chancen; nicht selbst-gemanagte Scrum Teams behindern die Fähigkeit, mit Komplexität umzugehen (30-35). selbst-gemanagte Scrum Teams sind nicht zu verwechseln mit individueller Selbst-Management.
 
 **Elemente von Scrum**
 
-1\. Scrum-Theorie: Basiert auf drei Säulen:
+1\. Scrum-Theorie: Basiert auf drei Säulen (Three Pillars):
 
-- Transparenz – Arbeit und Wert für die Überprüfung sichtbar machen.
-- Überprüfung – Regelmäßige Bewertung von Fortschritten und Ergebnissen zur Anpassung.
-- Anpassung – Anpassung von Plänen auf der Grundlage von Erkenntnissen und Feedback.
+- Transparenz (Transparency)– Arbeit und Wert für die Überprüfung sichtbar machen.
+- Überprüfung (Inspection) – Regelmäßige Bewertung von Fortschritten und Ergebnissen zur Anpassung.
+- Anpassung – (Adaptation) Anpassung von Plänen auf der Grundlage von Erkenntnissen und Feedback.
 
-2\. Scrum-Werte:
+2\. Scrum-Werte (Scrum Values):
 
-- _Fokus_, _Offenheit_, _Mut_, _Engagement_ und _Respekt_ ermöglichen effektive Teamarbeit und fördern Vertrauen.
+- _Fokus_, _Offenheit_, _Mut_, _Engagement_ und _Respekt_ _(Focus, Openness, Courage, Commitment, Respect)_ ermöglichen effektive Teamarbeit und fördern Vertrauen.
 
 3\. _Rollen_ / Verantwortlichkeiten:
 
-- Scrum-Team – Ein kleines, selbst-gemanagtes, funktionsübergreifendes, kognitiv vielfältiges Team, bestehend aus:
+- Scrum Team – Ein kleines, selbst-gemanagtes, funktionsübergreifendes, kognitiv vielfältiges Team, bestehend aus:
 - Produkt Owner – Maximiert den langfristigen Wert, bindet Stakeholder ein und verwaltet das Product Backlog.
 - Scrum Master – Leitet die Einführung von Scrum, beseitigt Hindernisse und fördert kontinuierliche Verbesserungen.
-- Produktentwickler – Liefern durch ihre funktionsübergreifenden Fähigkeiten in jedem Sprint Inkremente.
+- Product Developer – Liefern durch ihre funktionsübergreifenden Fähigkeiten in jedem Sprint Inkremente.
 - _Stakeholder – Eine Einheit, Einzelperson oder Gruppe, die an Inputs, Aktivitäten und Ergebnissen interessiert ist, von diesen betroffen ist oder diese beeinflusst und ein direktes oder indirektes Interesse innerhalb oder außerhalb der Organisation, ihrer Produkte oder Dienstleistungen hat.
 - _Supporter, ein Stakeholder-Typ – Fördert das Klima und die Umgebung und beteiligt sich nach Bedarf.
-- _KI – Als Werkzeug oder auch als möglicher Produktentwickler, dem jedoch noch nicht vollständig vertraut werden sollte.
+- _KI (AI)– Als Werkzeug oder auch als möglicher Product Developer, dem jedoch noch nicht vollständig vertraut werden sollte.
 
 4\. Scrum-Ereignisse und -Aktivitäten
 
 - Scrum arbeitet in Sprints (Iterationen von festgelegter Länge _bis zu vier Wochen_) mit vier zeitlich begrenzten Ereignissen:
 - Sprint-Planung – Definieren Sie das Sprint-Ziel und planen Sie die Arbeit.
-- Tägliches Scrum – Produktentwickler stimmen sich täglich über den Fortschritt in Richtung des Sprint-Ziels oder Produktziels ab.
+- Tägliches Scrum – Product Developer stimmen sich täglich über den Fortschritt in Richtung des Sprint-Ziels oder Produktziels ab.
 - Sprint-Review – Überprüfen Sie den Inkrement, den Wert und den Markt und passen Sie das Product Backlog an.
-- Sprint Retrospective – Reflexion und Verbesserung des Scrum-Teams.
+- Sprint Retrospective – Reflexion und Verbesserung des Scrum Teams.
 - Refinement – Klärung anstehender oder ausgewählter Arbeiten, formell (als optionales Ereignis) oder informell
 
 5\. Scrum-Artefakte und Verpflichtungen
@@ -864,13 +864,13 @@ Scrum ermöglicht es Scrum-Teams, Emergenz (71) zu identifizieren, darzustellen 
 Ergänzungen
 
 - Abschnitt „KI”
-- Abschnitte „selbst-gemanagtes Scrum-Team”, „Kadenz” und „Professionalität”
+- Abschnitte „selbst-gemanagtes Scrum Team”, „Kadenz” und „Professionalität”
 - Abschnitt „Entstehung”, offen für die Idee, dass Risiken oder Abweichungen von den Erwartungen nicht unbedingt mit der Zeit abnehmen
 - Abschnitt „Komplexität (30–35) – Argumente für Scrum”
 - Abschnitte „Führung” und „Systemisches Denken”
 - Abschnitte „Produktdenken” und „Entdeckung”
 - Abschnitte „Grundprinzipien”, „Menschen” und „Veränderung”
-- Abschnitt „Produkte mit mehreren Scrum-Teams”
+- Abschnitt „Produkte mit mehreren Scrum Teams”
 - Rolle der Stakeholder (einschließlich Kunden, Entscheidungsträger und Nutzer), Unterstützer als Stakeholder-Typ
 - Abschnitte „Verfeinerung” und „Eintrag im Product Backlog”
 - Optional: Produktvision, Akzeptanzkriterien, Ergebniskriterien
@@ -880,7 +880,7 @@ Ergänzungen
 - Scrum Expanded auf einer Seite
 - Die Notwendigkeit, Arbeitsabläufe, Designs, Prozesse, Systeme und die Arbeitsumgebung mit der Emergenz in Einklang zu bringen
 - „Produktverantwortung erfordert ausgeprägte Produktmanagementfähigkeiten und Fachkenntnisse ... Ein Produkt Owner, der nicht bereit, willens oder in der Lage ist, Produktmanagementfähigkeiten zu erwerben, sollte als Produkt Owner zurücktreten.“
-- Ein Produktentwickler, der weder bereit noch in der Lage ist, ein Profi zu sein, sollte zurücktreten.
+- Ein Product Developer, der weder bereit noch in der Lage ist, ein Profi zu sein, sollte zurücktreten.
 - Ein Scrum Master, der weder bereit noch in der Lage ist, als Change Agent zu fungieren, sollte zurücktreten.
 - Anhänge: Cynefin®-Erläuterungen – inoffiziell und nicht autorisiert, Emergent Strategy, Adaptive (80) Enterprise, Adaptive Executive oder Board Member
 
@@ -889,10 +889,10 @@ Vorschläge
 - Klärung und Änderung von Verantwortlichkeiten unter Berücksichtigung von „Unschärfen” (73)
 - Von „Scrum ist unveränderlich oder einfach” zu „Scrum entwickelt sich weiter”, in einigen Fällen abgeschwächte Formulierungen von „muss” zu „sollte”
 - Produkt Owner ist für die Rolle des Produkt Owners verantwortlich und rechenschaftspflichtig; Maximierung des langfristigen Werts
-- Entwickler sind für die Rolle des Produktentwicklers verantwortlich und rechenschaftspflichtig
+- Entwickler sind für die Rolle des Product Developers verantwortlich und rechenschaftspflichtig
 - Scrum Master ist für die Rolle des Scrum Masters verantwortlich und rechenschaftspflichtig; Scrum Master ist eine Person, keine KI
-- Produktentwickler können Menschen oder KI sein oder von KI unterstützt werden, mindestens jedoch ein Mensch; mehr menschliche Produktentwickler sind besser für die kognitive Vielfalt und die Bewältigung von Komplexität
-- Das Scrum-Team verpflichtet sich zum Sprint-Ziel, nicht die früheren Entwickler; wichtig ist, dass der Produkt Owner fokussiert ist
+- Product Developer können Menschen oder KI sein oder von KI unterstützt werden, mindestens jedoch ein Mensch; mehr menschliche Product Developer sind besser für die kognitive Vielfalt und die Bewältigung von Komplexität
+- Das Scrum Team verpflichtet sich zum Sprint-Ziel, nicht die früheren Entwickler; wichtig ist, dass der Produkt Owner fokussiert ist
 - Sprint-Backlog in Richtung Sprint-Ziel oder Produktziel, nicht nur Sprint-Ziel
 - Produktdefinition, Erwähnung von Produktstrategie, Roadmaps, Produktmodellen, Skalierung, zielorientierten Ansätzen
 - Schwerpunkt auf Lernen, Ergebnis-Feedback, Nebenwirkungen, Ergebnissen statt Outputs
@@ -921,7 +921,7 @@ Hinweis: Dieser Abschnitt wird mit Genehmigung unter den Bedingungen der Lizenz 
 
 ### Das adaptive Unternehmen {#the-adaptive-enterprise}
 
-Für ein Unternehmen ist es schwierig, adaptiv zu sein (80), wenn Worte und Taten nicht übereinstimmen. Über achtzig Engagement-Modelle wurden untersucht. Darunter befanden sich Skalierungs- oder Deskalierungs-Frameworks und Produktbetriebsmodelle, die für Produkte mit mehreren Scrum-Teams nützlich sein können. Die Modelle reichen von zu weitreichenden bis zu unzureichenden Maßnahmen, um die Produktorganisation dabei zu unterstützen, adaptiver zu werden. Es gibt keine allgemeingültige Wahrheit oder kontextunabhängige „Goldilocks-Zone”.
+Für ein Unternehmen ist es schwierig, adaptiv zu sein (80), wenn Worte und Taten nicht übereinstimmen. Über achtzig Engagement-Modelle wurden untersucht. Darunter befanden sich Skalierungs- oder Deskalierungs-Frameworks und Produktbetriebsmodelle, die für Produkte mit mehreren Scrum Teams nützlich sein können. Die Modelle reichen von zu weitreichenden bis zu unzureichenden Maßnahmen, um die Produktorganisation dabei zu unterstützen, adaptiver zu werden. Es gibt keine allgemeingültige Wahrheit oder kontextunabhängige „Goldilocks-Zone”.
 
 Unter den untersuchten Engagement-Modellen gibt es eine Reihe bemerkenswerter Kandidaten, darunter Beyond Budgeting, Humanocracy und Sociocracy, die je nach Kontext geprüft werden sollten. Erwägen Sie die Kombination untereinander und mit anderen Ansätzen.
 
@@ -1005,7 +1005,7 @@ Cynefin® (30-35) bietet einen Kompass für Führungsentscheidungen. Es wurde du
 
 Eine Phasenverschiebung bezieht sich auf einen oft abrupten Übergang zwischen Bereichen, insbesondere vom geordneten zum chaotischen Zustand, der ausgelöst wird, wenn die Beschränkungen eines Systems (Regeln, Gewohnheiten, Grenzen und Rückkopplungen) nicht mehr aufeinander abgestimmt sind oder zusammenbrechen. Sie markiert eine grundlegende Veränderung im Systemverhalten, bei der bisherige Methoden der Kontrolle oder des Verständnisses nicht mehr funktionieren.
 
-Nicht alle Aspekte der Produktentwicklung sind komplex. Das Scrum-Team muss für eine gegebene Situation möglicherweise eine Vielzahl von Phasenverschiebungen zwischen folgenden Bereichen berücksichtigen:
+Nicht alle Aspekte der Produktentwicklung sind komplex. Das Scrum Team muss für eine gegebene Situation möglicherweise eine Vielzahl von Phasenverschiebungen zwischen folgenden Bereichen berücksichtigen:
 
 - Geordnet: Schlüsselbegriff: Stabilität, Routine, Best/Good Practice, Fachwissen
 
@@ -1135,11 +1135,11 @@ In Situationen, in denen Fachwissen allein ausreicht (oder fast ausreicht), um s
 - Listen von Aktivitäten oder Initiativen (das „Was wir tun werden” oder „Wie”).
 - Vermeiden Sie es, eine Sammlung von Projekten mit einer kohärenten, wertorientierten Strategie zu verwechseln.
 
-In Situationen, in denen Fachwissen wertvoll, aber nicht ausreichend ist, Ursache und Wirkung nur im Nachhinein kohärent sind und Unsicherheit akzeptiert werden muss, müssen Scrum-Teams und Stakeholder Folgendes tun:
+In Situationen, in denen Fachwissen wertvoll, aber nicht ausreichend ist, Ursache und Wirkung nur im Nachhinein kohärent sind und Unsicherheit akzeptiert werden muss, müssen Scrum Teams und Stakeholder Folgendes tun:
 
 - Akzeptieren Sie die Unordnung einer weniger strukturierten und emergenten, ergebnisorientierten Arbeit in einer bestimmten Richtung.
 - Bedenken Sie, dass detaillierte, langfristige Pläne ineffektiv sind. Stattdessen sollten sich Organisationen darauf konzentrieren, Bedingungen zu schaffen, unter denen sich aus den Interaktionen innerhalb des Systems nützliche Muster und Innovationen entwickeln können.
-- Anstatt eine Idee nach der anderen auszuprobieren und an Bewährtem festzuhalten, sollten Scrum-Teams mehrere kleine, parallel durchführbare Experimente in Betracht ziehen, um zu sehen, was passiert, und aus den Ergebnissen zu lernen.
+- Anstatt eine Idee nach der anderen auszuprobieren und an Bewährtem festzuhalten, sollten Scrum Teams mehrere kleine, parallel durchführbare Experimente in Betracht ziehen, um zu sehen, was passiert, und aus den Ergebnissen zu lernen.
 - Fördern Sie ein Klima für kreative Erkundungen, Innovationen und Weiterentwicklungen aus der Gegenwart heraus. Schaffen Sie Prozesse und Umgebungen, in denen Menschen neue Ideen, Erkenntnisse und fundierte Vermutungen miteinander verbinden und voneinander lernen können, anstatt Uniformität oder starre KPIs vorzugeben.
 - Die Reaktionsmöglichkeiten sind nicht beschränkt auf:
 - Erfassen Sie bereits bekannte Informationen und verstehen Sie das Entwicklungspotenzial des Systems, bevor Sie Veränderungen versuchen.
@@ -1164,7 +1164,7 @@ Dennoch:
 
 Eine emergente Strategie wird durch einen emergenten, ergebnisorientierten Fahrplan unterstützt, der vom Sprint-Ziel bis zur Produktvision und darüber hinaus reichen kann. Die Umsetzung einer emergenten Strategie (120-123) sollte nicht mit einer emergenten Strategie verwechselt werden. Vektoränderungsmodelle (30-35, 54), Produktbetriebsmodelle (113-119), Skalierungs- und Deskalierungsmodelle (134-147) und emergente zielorientierte Modelle (120-133) können für die Umsetzung einer emergenten Strategie sehr nützlich sein. Halten Sie sich eher an Modelle, die mit Vektoränderungen übereinstimmen, z. B. die Richtung der Entwicklung gegenüber festen Zielen.
  
-Die Umsetzung emergenter Strategien beinhaltet, dass Pläne und Maßnahmen sich auf natürliche Weise entwickeln können, während das Scrum-Team und die Stakeholder auf reale Veränderungen reagieren. Anstatt einem festen Pfad zu folgen, achten sie auf das, was um sie herum geschieht, und nehmen im Laufe der Zeit Anpassungen vor. Mit der Zeit bilden die unternommenen Schritte ein Muster, das zur eigentlichen Strategie wird, auch wenn diese sich von der ursprünglich beabsichtigten Strategie unterscheidet.
+Die Umsetzung emergenter Strategien beinhaltet, dass Pläne und Maßnahmen sich auf natürliche Weise entwickeln können, während das Scrum Team und die Stakeholder auf reale Veränderungen reagieren. Anstatt einem festen Pfad zu folgen, achten sie auf das, was um sie herum geschieht, und nehmen im Laufe der Zeit Anpassungen vor. Mit der Zeit bilden die unternommenen Schritte ein Muster, das zur eigentlichen Strategie wird, auch wenn diese sich von der ursprünglich beabsichtigten Strategie unterscheidet.
 
 #
 
@@ -1245,7 +1245,7 @@ _Mitglieder der Scrum Patterns Group: Vervloed, E., Harrison, N., Harada, K., Yo
 66. _Creative Wisdom (o. J.) „Abduction, Deduction and Induction”. Verfügbar unter: [https://www.creative-wisdom.com/teaching/WBI/abduction5.pdf](https://www.creative-wisdom.com/teaching/WBI/abduction5.pdf) (Zugriff: 17. Mai 2025)._
 67. _Campbell, J. (2025) „Empiricism”, EBSCO Research Starters. Verfügbar unter: [https://www.ebsco.com/research-starters/religion-and-philosophy/empiricism](https://www.ebsco.com/research-starters/religion-and-philosophy/empiricism) (Zugriff: 17. Mai 2025)
 68. _Kanban Guides (2025) Verfügbar unter: [https://kanbanguides.org](https://kanbanguides.org/) (Zugriff: 17. Mai 2025)
-69. [_Scrum.org_](http://Scrum.org) _et al. (2021) The Kanban Guide for Scrum Teams. Verfügbar unter: [https://www.scrum.org/resources/kanban-guide-scrum-teams](https://www.scrum.org/resources/kanban-guide-scrum-teams) (Zugriff: 17. Mai 2025) 
+69. [_Scrum.org_](http://Scrum.org) _et al. (2021) The Kanban Guide for Scrum Teams. Verfügbar unter: [https://www.scrum.org/resources/kanban-guide-Scrum Teams](https://www.scrum.org/resources/kanban-guide-Scrum Teams) (Zugriff: 17. Mai 2025) 
 70. Csíkszentmihályi, M. (1990) Flow: The Psychology of Optimal Experience. New York: Harper & Row_
 71. _Templeton Foundation (2023) „What Is Emergence?” John Templeton Foundation. Verfügbar unter: [https://www.templeton.org/news/what-is-emergence](https://www.templeton.org/news/what-is-emergence) (Zugriff: 17. Mai 2025)._
 72. _van der Bles, A.M., van der Linden, S., Freeman, A.L.J. und Spiegelhalter, D.J. (2019) „Communicating uncertainty about facts, numbers and science”, Royal Society Open Science, 6(5), 181870\. Verfügbar unter: [https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6549952/](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6549952/) (Zugriff: 17. Mai 2025)._


### PR DESCRIPTION
Went through the Translation Code of Conduct and applied especially section 5 rule, to ensure doc consistency with Scrum Guide and English Expansion Pack terms.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/141)
<!-- Reviewable:end -->
