### PR TITLE
Update stale-issues.yml

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -37,8 +37,8 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-issue-stale: 10
-          days-before-issue-close: 5
+          days-before-issue-stale: 20
+          days-before-issue-close: 10
           days-before-pr-stale: -1
           days-before-pr-close: -1
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity within the last 14 days. It will be closed if no further activity occurs."


### PR DESCRIPTION
This pull request updates the configuration for the stale issues workflow in `.github/workflows/stale-issues.yml`. The most notable change is the adjustment of the timeframes for marking issues as stale and for closing them.

Changes to stale issues workflow:

* Updated the `days-before-issue-stale` value from 10 to 20, increasing the time before an issue is marked as stale.
* Updated the `days-before-issue-close` value from 5 to 10, increasing the time before a stale issue is automatically closed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/149)
<!-- Reviewable:end -->
