### PR TITLE
Update hugo.production.yaml

### DIFF
--- a/site/hugo.production.yaml
+++ b/site/hugo.production.yaml
@@ -6,7 +6,7 @@ languages:
   tlh:
     disabled: true
   fa:
-    disabled: true
+    disabled: false
   pl:
     disabled: true
   nl:
@@ -14,4 +14,4 @@ languages:
   de:
     disabled: true
   es:
-    disabled: true
+    disabled: false


### PR DESCRIPTION
This pull request updates the language configuration in the `site/hugo.production.yaml` file to enable support for Persian (`fa`) and Spanish (`es`) languages.

* [`site/hugo.production.yaml`](diffhunk://#diff-b30079d21c29b4e42a159e2d01428365fa9bcb235876d733e39270eda77fd29bL9-R17): Changed the `disabled` status for Persian (`fa`) and Spanish (`es`) languages from `true` to `false`, enabling these languages on the site.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/174)
<!-- Reviewable:end -->
