### PR TITLE
fix: correct Wikipedia URL capitalization for Genchi Genbutsu reference

### DIFF
--- a/site/content/scrum-guide-expansion-pack/2025.6/index.de.md
+++ b/site/content/scrum-guide-expansion-pack/2025.6/index.de.md
@@ -1253,7 +1253,7 @@ _Mitglieder der Scrum Patterns Group: Vervloed, E., Harrison, N., Harada, K., Yo
 81. _Sociocracy For All (o. J.) „Gerard Endenburg: Begründer der Soziokratischen Kreismethode und Pionier der Selbst-Management“. Verfügbar unter: [https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/](https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/) (Zugriff: 18. Mai 2025)._
 82. _Patton, J. und Economy, P. (2014) User Story Mapping: Discover the Whole Story, Build the Right Product. Sebastopol, CA: O’Reilly Media._
 83. _Kotter, J.P., 1996\. Leading Change. Boston: Harvard Business School Press._
-84. _„Genchi Genbutsu” (2024) Wikipedia. Verfügbar unter: [https://en.wikipedia.org/wiki/Genchi_genbutsu](https://en.wikipedia.org/wiki/Genchi_genbutsu) (Zugriff: 18. Mai 2025)._
+84. _„Genchi Genbutsu” (2024) Wikipedia. Verfügbar unter: [https://en.wikipedia.org/wiki/Genchi_Genbutsu](https://en.wikipedia.org/wiki/Genchi_Genbutsu) (Zugriff: 18. Mai 2025)._
 85. _ScrumPlop, o. J. Illigitimus Non Interruptis. The Scrum Book: The Spirit of the Game. Verfügbar unter: [https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus](https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus) \[Zugriff: 18. Mai 2025\]._
 86. _Cagan, M., 2018\. Inspired: How to Create Tech Products Customers Love. 2. Auflage. Hoboken, NJ: Wiley._
 87. _Cagan, M. & Jones, C., 2020\. Empowered: Ordinary People, Extraordinary Products. Hoboken, NJ: Wiley._

--- a/site/content/scrum-guide-expansion-pack/2025.6/index.es.md
+++ b/site/content/scrum-guide-expansion-pack/2025.6/index.es.md
@@ -1297,7 +1297,7 @@ Esta colección fue escrita y compilada por Ralph Jocham, John Coleman y Jeff Su
 81. _Sociocracy For All (n.d.) ‘Gerard Endenburg: founder of Sociocratic Circle Method and pioneer of self-management’. Available at: [https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/](https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/) (Accessed: 18 May 2025)._
 82. _Patton, J. and Economy, P. (2014) User Story Mapping: Discover the Whole Story, Build the Right Product. Sebastopol, CA: O’Reilly Media._
 83. _Kotter, J.P., 1996\. Leading Change. Boston: Harvard Business School Press._
-84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_genbutsu](https://en.wikipedia.org/wiki/Genchi_genbutsu) (Accessed: 18 May 2025)._
+84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_Genbutsu](https://en.wikipedia.org/wiki/Genchi_Genbutsu) (Accessed: 18 May 2025)._
 85. _ScrumPlop, n.d. Illigitimus Non Interruptis. The Scrum Book: The Spirit of the Game. Available at: [https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus](https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus) \[Accessed: 18 May 2025\]._
 86. _Cagan, M., 2018\. Inspired: How to Create Tech Products Customers Love. 2nd ed. Hoboken, NJ: Wiley._
 87. _Cagan, M. & Jones, C., 2020\. Empowered: Ordinary People, Extraordinary Products. Hoboken, NJ: Wiley._

--- a/site/content/scrum-guide-expansion-pack/2025.6/index.fa.md
+++ b/site/content/scrum-guide-expansion-pack/2025.6/index.fa.md
@@ -1338,7 +1338,7 @@ _تبادل سازمانی آموخته‌ها_—بر اساس مقاله‌ی 
 81. _Sociocracy For All (n.d.) ‘Gerard Endenburg: founder of Sociocratic Circle Method and pioneer of self-management’. Available at: [https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/](https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/) (Accessed: 18 May 2025)._
 82. _Patton, J. and Economy, P. (2014) User Story Mapping: Discover the Whole Story, Build the Right Product. Sebastopol, CA: O’Reilly Media._
 83. _Kotter, J.P., 1996\. Leading Change. Boston: Harvard Business School Press._
-84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_genbutsu](https://en.wikipedia.org/wiki/Genchi_genbutsu) (Accessed: 18 May 2025)._
+84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_Genbutsu](https://en.wikipedia.org/wiki/Genchi_Genbutsu) (Accessed: 18 May 2025)._
 85. _ScrumPlop, n.d. Illigitimus Non Interruptis. The Scrum Book: The Spirit of the Game. Available at: [https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus](https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus) \[Accessed: 18 May 2025\]._
 86. _Cagan, M., 2018\. Inspired: How to Create Tech Products Customers Love. 2nd ed. Hoboken, NJ: Wiley._
 87. _Cagan, M. & Jones, C., 2020\. Empowered: Ordinary People, Extraordinary Products. Hoboken, NJ: Wiley._

--- a/site/content/scrum-guide-expansion-pack/2025.6/index.nl.md
+++ b/site/content/scrum-guide-expansion-pack/2025.6/index.nl.md
@@ -1253,7 +1253,7 @@ Deze collectie is geschreven en samengesteld door Ralph Jocham, John Coleman en 
 81. _Sociocracy For All (n.d.) ‘Gerard Endenburg: founder of Sociocratic Circle Method and pioneer of self-management’. Available at: [https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/](https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/) (Accessed: 18 May 2025)._
 82. _Patton, J. and Economy, P. (2014) User Story Mapping: Discover the Whole Story, Build the Right Product. Sebastopol, CA: O’Reilly Media._
 83. _Kotter, J.P., 1996\. Leading Change. Boston: Harvard Business School Press._
-84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_genbutsu](https://en.wikipedia.org/wiki/Genchi_genbutsu) (Accessed: 18 May 2025)._
+84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_Genbutsu](https://en.wikipedia.org/wiki/Genchi_Genbutsu) (Accessed: 18 May 2025)._
 85. _ScrumPlop, n.d. Illigitimus Non Interruptis. The Scrum Book: The Spirit of the Game. Available at: [https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus](https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus) \[Accessed: 18 May 2025\]._
 86. _Cagan, M., 2018\. Inspired: How to Create Tech Products Customers Love. 2nd ed. Hoboken, NJ: Wiley._
 87. _Cagan, M. & Jones, C., 2020\. Empowered: Ordinary People, Extraordinary Products. Hoboken, NJ: Wiley._

--- a/site/content/scrum-guide-expansion-pack/2025.6/index.pl.md
+++ b/site/content/scrum-guide-expansion-pack/2025.6/index.pl.md
@@ -1370,7 +1370,7 @@ Poniżej zamieszczamy glosariusz sugerowany przez twórców Scrum Guide Expansio
 81. _Sociocracy For All (n.d.) ‘Gerard Endenburg: founder of Sociocratic Circle Method and pioneer of self-management’. Available at: [https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/](https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/) (Accessed: 18 May 2025)._
 82. _Patton, J. and Economy, P. (2014) User Story Mapping: Discover the Whole Story, Build the Right Product. Sebastopol, CA: O’Reilly Media._
 83. _Kotter, J.P., 1996\. Leading Change. Boston: Harvard Business School Press._
-84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_genbutsu](https://en.wikipedia.org/wiki/Genchi_genbutsu) (Accessed: 18 May 2025)._
+84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_Genbutsu](https://en.wikipedia.org/wiki/Genchi_Genbutsu) (Accessed: 18 May 2025)._
 85. _ScrumPlop, n.d. Illigitimus Non Interruptis. The Scrum Book: The Spirit of the Game. Available at: [https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus](https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus) \[Accessed: 18 May 2025\]._
 86. _Cagan, M., 2018\. Inspired: How to Create Tech Products Customers Love. 2nd ed. Hoboken, NJ: Wiley._
 87. _Cagan, M. & Jones, C., 2020\. Empowered: Ordinary People, Extraordinary Products. Hoboken, NJ: Wiley._

--- a/site/content/scrum-guide-expansion-pack/2025.6/index.tlh.md
+++ b/site/content/scrum-guide-expansion-pack/2025.6/index.tlh.md
@@ -1248,7 +1248,7 @@ This collection was written and compiled by _Ralph Jocham, John Coleman, and Jef
 81. _Sociocracy For All (n.d.) ‘Gerard Endenburg: founder of Sociocratic Circle Method and pioneer of self-management’. Available at: [https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/](https://www.sociocracyforall.org/gerard-endenburg-founder-of-sociocratic-circle-method-and-pioneer-of-self-management/) (Accessed: 18 May 2025)._
 82. _Patton, J. and Economy, P. (2014) User Story Mapping: Discover the Whole Story, Build the Right Product. Sebastopol, CA: O’Reilly Media._
 83. _Kotter, J.P., 1996\. Leading Change. Boston: Harvard Business School Press._
-84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_genbutsu](https://en.wikipedia.org/wiki/Genchi_genbutsu) (Accessed: 18 May 2025)._
+84. _‘Genchi Genbutsu’ (2024) Wikipedia. Available at: [https://en.wikipedia.org/wiki/Genchi_Genbutsu](https://en.wikipedia.org/wiki/Genchi_Genbutsu) (Accessed: 18 May 2025)._
 85. _ScrumPlop, n.d. Illigitimus Non Interruptis. The Scrum Book: The Spirit of the Game. Available at: [https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus](https://sites.google.com/a/scrumplop.org/published-patterns/product-organization-pattern-language/illegitimus-non-interruptus) \[Accessed: 18 May 2025\]._
 86. _Cagan, M., 2018\. Inspired: How to Create Tech Products Customers Love. 2nd ed. Hoboken, NJ: Wiley._
 87. _Cagan, M. & Jones, C., 2020\. Empowered: Ordinary People, Extraordinary Products. Hoboken, NJ: Wiley._


### PR DESCRIPTION
correct Wikipedia URL capitalization for Genchi Genbutsu reference

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/215)
<!-- Reviewable:end -->
