### PR TITLE
Remove Docs not launching today

### DIFF
--- a/site/content/adaptive-enterprise/_index.md
+++ b/site/content/adaptive-enterprise/_index.md
@@ -13,5 +13,15 @@ categories:
   - Leadership
 sitemap:
   priority: 0.8
-
+cascade:
+  - build:
+      list: never
+      render: never
+    target:
+      environment: production
+  - build:
+      list: never
+      render: never
+    target:
+      environment: preview
 ---

--- a/site/content/emergent-strategy-and-depoyment/_index.md
+++ b/site/content/emergent-strategy-and-depoyment/_index.md
@@ -18,6 +18,11 @@ cascade:
       render: never
     target:
       environment: production
+  - build:
+      list: never
+      render: never
+    target:
+      environment: preview
 sitemap:
   priority: 0.8
 ---


### PR DESCRIPTION
This pull request updates build configuration in two content index files to improve deployment control for different environments. The changes ensure that both production and preview environments do not render or list these content pages.

Build and deployment configuration updates:

* In `site/content/adaptive-enterprise/_index.md`, added a `cascade` block to prevent listing and rendering for both production and preview environments.
* In `site/content/emergent-strategy-and-depoyment/_index.md`, extended the existing `cascade` block to also prevent listing and rendering for the preview environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/297)
<!-- Reviewable:end -->
