### PR TITLE
Update Counters

### DIFF
--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -34,13 +34,22 @@
           <div class="row g-4 mb-5 justify-content-center">
             <div class="col-4 col-md-3">
               <div class="text-center">
-                <div class="display-6 fw-bold text-primary mb-2">{{ len .Site.Sections }}+</div>
+                <div class="display-6 fw-bold text-primary mb-2">{{ len (where .Site.Sections "Type" "guide") }}+</div>
                 <div class="small text-muted">{{ i18n "expansions" | default "Expansions" }}</div>
               </div>
             </div>
             <div class="col-4 col-md-3">
               <div class="text-center">
-                <div class="display-6 fw-bold text-primary mb-2">3</div>
+                {{- $uniqueContributors := slice }}
+                {{- range $key, $value := .Site.Data.contributions }}
+                  {{- range $value }}
+                    {{- $identifier := .githubUsername | default .name }}
+                    {{- if not (in $uniqueContributors $identifier) }}
+                      {{- $uniqueContributors = $uniqueContributors | append $identifier }}
+                    {{- end }}
+                  {{- end }}
+                {{- end }}
+                <div class="display-6 fw-bold text-primary mb-2">{{ len $uniqueContributors }}</div>
                 <div class="small text-muted">{{ i18n "expert_authors" | default "Expert Authors" }}</div>
               </div>
             </div>


### PR DESCRIPTION
This pull request updates the statistics shown on the homepage to provide more accurate and dynamic counts for expansions and expert authors.

**Homepage statistics improvements:**

* Changed the expansions count to display only the number of sections of type `"guide"` instead of all site sections, making the statistic more relevant.
* Updated the expert authors count to dynamically calculate the number of unique contributors based on their GitHub usernames or names, instead of displaying a hardcoded value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/304)
<!-- Reviewable:end -->
