### PR TITLE
Fix deployment workflow to build Hugo manually

### DIFF
--- a/.github/workflows/azure-static-web-apps-agreeable-island-0c966e810.yml
+++ b/.github/workflows/azure-static-web-apps-agreeable-island-0c966e810.yml
@@ -1,38 +1,41 @@
 name: Azure Static Web Apps CI/CD
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: false
+        default: 'main'
 
 jobs:
   build_and_deploy_job:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           lfs: false
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.146.0'
+          extended: true
+
+      - name: Build Hugo site
+        run: hugo --minify --environment production
+        working-directory: ./site
+
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_ISLAND_0C966E810 }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
-          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "./site" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "." # Built app content directory - optional
-          ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_AGREEABLE_ISLAND_0C966E810 }}
-          action: "close"
+          app_location: "./site"
+          api_location: ""
+          output_location: "public"
+          skip_app_build: true


### PR DESCRIPTION
## Summary
- Install Hugo Extended v0.146.0 via peaceiris/actions-hugo@v3 to avoid Oryx unsupported Go 1.24.5 error
- Build site with hugo --minify --environment production before deploying
- Set skip_app_build to bypass Oryx build entirely
- Add branch input selector for workflow_dispatch
- Update actions/checkout from v3 to v4
- Remove dead close_pull_request_job (unreachable with workflow_dispatch trigger)

## Test plan
- [ ] Trigger the workflow manually from Actions tab and confirm it builds and deploys successfully

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ScrumGuides/ScrumGuide-ExpansionPack/332)
<!-- Reviewable:end -->
